### PR TITLE
Enhance repo selection quiz

### DIFF
--- a/components/sections/repo-questions.js
+++ b/components/sections/repo-questions.js
@@ -14,6 +14,7 @@ import {
 } from "@mui/icons-material"
 
 const RepoQuestions = ({ data }) => {
+  console.log(data)
   const [value, setValue] = React.useState("")
   const [showOptions, setShowOptions] = React.useState(true)
   const [optionalInformation, setOptionalInformation] = React.useState(false)
@@ -57,7 +58,7 @@ const RepoQuestions = ({ data }) => {
         Back
       </Button>
     ),
-    [questionToShow]
+    [handleClickBack, questionToShow]
   )
 
   const StartOverButton = React.useCallback(
@@ -71,7 +72,7 @@ const RepoQuestions = ({ data }) => {
         Start Over
       </Button>
     ),
-    []
+    [optionalInformation, questionToShow]
   )
 
   return (
@@ -85,8 +86,8 @@ const RepoQuestions = ({ data }) => {
       {data.repo_question.map((q, i) => {
         if (i + 1 === questionToShow) {
           return (
-            <div className={"repo-questions"} key={q.question}>
-              <Markdown className={"repo-questions"}>{q.question}</Markdown>
+            <div className="repo-questions" key={q.question}>
+              <Markdown className="repo-questions">{q.question}</Markdown>
               <br></br>
               {showOptions && (
                 <div>
@@ -130,10 +131,34 @@ const RepoQuestions = ({ data }) => {
                 </div>
               )}
 
+              {!showOptions && (
+                <Box
+                  sx={{
+                    borderLeft: "6px solid",
+                    borderLeftColor: "primary.light",
+                    backgroundColor: "rgb(229, 224, 232)",
+                    my: 6,
+                    p: 2,
+                  }}
+                >
+                  <Markdown>
+                    Once you have selected a repository, please report your
+                    selection to the HEAL Stewards by emailing
+                    [HEALStewards@renci.org](mailto:HEALStewards@renci.org), or
+                    the Platform Team via the [Platform Help
+                    Desk](https://heal.github.io/platform-documentation/contact/).
+                    For more information or repository selection assistance,
+                    please [contact the HEAL
+                    Stewards](https://forms.fillout.com/t/gcVveGMswBus).
+                  </Markdown>
+                </Box>
+              )}
+
               <Box
                 sx={{
                   display: "flex",
                   flexDirection: "row",
+                  justifyContent: "center",
                   gap: 1,
                   mt: 3,
                 }}

--- a/components/sections/repo-questions.js
+++ b/components/sections/repo-questions.js
@@ -23,9 +23,13 @@ const RepoQuestions = ({ data }) => {
     setQuestionToShow(1)
     setOptionalInformation(false)
     setShowOptions(true)
+    setValue("")
   }
   const handleClickBack = () => {
     setQuestionToShow(Math.max(questionToShow - 1, 1))
+    setOptionalInformation(false)
+    setShowOptions(true)
+    setValue("")
   }
 
   const handleChange = (event) => {
@@ -62,6 +66,7 @@ const RepoQuestions = ({ data }) => {
         onClick={handleClickStartOver}
         variant="outlined"
         startIcon={<StartOverIcon />}
+        disabled={questionToShow === 1 && optionalInformation}
       >
         Start Over
       </Button>

--- a/components/sections/repo-questions.js
+++ b/components/sections/repo-questions.js
@@ -14,6 +14,7 @@ import {
 } from "@mui/icons-material"
 
 const RepoQuestions = ({ data }) => {
+  console.log(data)
   const [value, setValue] = React.useState("")
   const [showOptions, setShowOptions] = React.useState(true)
   const [optionalInformation, setOptionalInformation] = React.useState(false)
@@ -27,7 +28,6 @@ const RepoQuestions = ({ data }) => {
   }, [])
 
   const handleClickBack = React.useCallback(() => {
-    console.log({ questionToShow })
     setQuestionToShow(Math.max(questionToShow - 1, 1))
     setOptionalInformation(false)
     setShowOptions(true)
@@ -52,7 +52,7 @@ const RepoQuestions = ({ data }) => {
     () => (
       <Button
         onClick={handleClickBack}
-        disabled={questionToShow === 1 && !showOptions}
+        disabled={questionToShow === 1}
         variant="outlined"
         startIcon={<BackIcon />}
       >

--- a/components/sections/repo-questions.js
+++ b/components/sections/repo-questions.js
@@ -20,18 +20,19 @@ const RepoQuestions = ({ data }) => {
   const [optionalInformation, setOptionalInformation] = React.useState(false)
   const [questionToShow, setQuestionToShow] = React.useState(1)
 
-  const handleClickStartOver = () => {
+  const handleClickStartOver = useCallback(() => {
     setQuestionToShow(1)
     setOptionalInformation(false)
     setShowOptions(true)
     setValue("")
-  }
-  const handleClickBack = () => {
+  }, [])
+
+  const handleClickBack = useCallback(() => {
     setQuestionToShow(Math.max(questionToShow - 1, 1))
     setOptionalInformation(false)
     setShowOptions(true)
     setValue("")
-  }
+  }, [])
 
   const handleChange = (event) => {
     setValue(event.target.value)

--- a/components/sections/repo-questions.js
+++ b/components/sections/repo-questions.js
@@ -1,5 +1,6 @@
 import Markdown from "../elements/markdown"
 import * as React from "react"
+import { Box } from "@mui/material"
 import Radio from "@mui/material/Radio"
 import RadioGroup from "@mui/material/RadioGroup"
 import FormControlLabel from "@mui/material/FormControlLabel"
@@ -7,12 +8,25 @@ import FormControl from "@mui/material/FormControl"
 import { Button } from "@mui/material"
 import FileDownloadIcon from "@mui/icons-material/FileDownload"
 import { CSVLink, CSVDownload } from "react-csv"
+import {
+  KeyboardArrowLeft as BackIcon,
+  RestartAlt as StartOverIcon,
+} from "@mui/icons-material"
 
 const RepoQuestions = ({ data }) => {
   const [value, setValue] = React.useState("")
   const [showOptions, setShowOptions] = React.useState(true)
   const [optionalInformation, setOptionalInformation] = React.useState(false)
   const [questionToShow, setQuestionToShow] = React.useState(1)
+
+  const handleClickStartOver = () => {
+    setQuestionToShow(1)
+    setOptionalInformation(false)
+    setShowOptions(true)
+  }
+  const handleClickBack = () => {
+    setQuestionToShow(Math.max(questionToShow - 1, 1))
+  }
 
   const handleChange = (event) => {
     setValue(event.target.value)
@@ -28,6 +42,33 @@ const RepoQuestions = ({ data }) => {
     }
   }
 
+  const BackButton = React.useCallback(
+    () => (
+      <Button
+        onClick={handleClickBack}
+        disabled={questionToShow === 1}
+        variant="outlined"
+        startIcon={<BackIcon />}
+      >
+        Back
+      </Button>
+    ),
+    [questionToShow]
+  )
+
+  const StartOverButton = React.useCallback(
+    () => (
+      <Button
+        onClick={handleClickStartOver}
+        variant="outlined"
+        startIcon={<StartOverIcon />}
+      >
+        Start Over
+      </Button>
+    ),
+    []
+  )
+
   return (
     <div
       className="container pb-4 text-gray-dark"
@@ -37,7 +78,7 @@ const RepoQuestions = ({ data }) => {
       }}
     >
       {data.repo_question.map((q, i) => {
-        if (i + 1 == questionToShow) {
+        if (i + 1 === questionToShow) {
           return (
             <div className={"repo-questions"} key={q.question}>
               <Markdown className={"repo-questions"}>{q.question}</Markdown>
@@ -71,9 +112,7 @@ const RepoQuestions = ({ data }) => {
                   </FormControl>
                 </div>
               )}
-              {/* {nextButton && (
-                                <button>next button coming soon</button>
-                            )} */}
+
               {optionalInformation && (
                 <div>
                   <Markdown>{optionalInformation}</Markdown>
@@ -85,6 +124,18 @@ const RepoQuestions = ({ data }) => {
                   </Button>
                 </div>
               )}
+
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "row",
+                  gap: 1,
+                  mt: 3,
+                }}
+              >
+                <BackButton />
+                <StartOverButton />
+              </Box>
             </div>
           )
         }

--- a/components/sections/repo-questions.js
+++ b/components/sections/repo-questions.js
@@ -14,25 +14,25 @@ import {
 } from "@mui/icons-material"
 
 const RepoQuestions = ({ data }) => {
-  console.log(data)
   const [value, setValue] = React.useState("")
   const [showOptions, setShowOptions] = React.useState(true)
   const [optionalInformation, setOptionalInformation] = React.useState(false)
   const [questionToShow, setQuestionToShow] = React.useState(1)
 
-  const handleClickStartOver = useCallback(() => {
+  const handleClickStartOver = React.useCallback(() => {
     setQuestionToShow(1)
     setOptionalInformation(false)
     setShowOptions(true)
     setValue("")
   }, [])
 
-  const handleClickBack = useCallback(() => {
+  const handleClickBack = React.useCallback(() => {
+    console.log({ questionToShow })
     setQuestionToShow(Math.max(questionToShow - 1, 1))
     setOptionalInformation(false)
     setShowOptions(true)
     setValue("")
-  }, [])
+  }, [questionToShow])
 
   const handleChange = (event) => {
     setValue(event.target.value)
@@ -52,7 +52,7 @@ const RepoQuestions = ({ data }) => {
     () => (
       <Button
         onClick={handleClickBack}
-        disabled={questionToShow === 1}
+        disabled={questionToShow === 1 && !showOptions}
         variant="outlined"
         startIcon={<BackIcon />}
       >
@@ -66,9 +66,9 @@ const RepoQuestions = ({ data }) => {
     () => (
       <Button
         onClick={handleClickStartOver}
+        disabled={questionToShow === 1 && showOptions}
         variant="outlined"
         startIcon={<StartOverIcon />}
-        disabled={questionToShow === 1 && optionalInformation}
       >
         Start Over
       </Button>


### PR DESCRIPTION
this PR addresses two pieces of feedback from the original implementation of this tool:
- add back and start over buttons at each step
- add guidance box when terminal node is reached

see here: https://repo-selection-quiz.d1mcdngnks37uk.amplifyapp.com/repository-decision-tree