### PR TITLE
fix repo_name reference

### DIFF
--- a/components/sections/app-search.js
+++ b/components/sections/app-search.js
@@ -279,7 +279,7 @@ export default function AppSearch({ data }) {
           dataSubmitted: hasDataLink,
           linkProvided: hasDataLink,
           additionalInformation: hasDataLink
-            ? `Congratulations on submitting your data to ${repo_repository_name}!`
+            ? `Congratulations on submitting your data to ${repo.repository_name}!`
             : `If you've submitted data to ${repo.repository_name}, please submit the corresponding link to the Platform at [heal-support@gen3.org](mailto:heal-support@gen3.org). If you are not ready to submit your data and VLMD to a repository, that's okay\! Revisit this when you're ready, and feel free to reach out to us with any questions or if you need assistance.`,
         })
       }


### PR DESCRIPTION
I’ve been notified that the following study in the progress tracker is no longer working: [https://www.healdatafair.org/app-search?data=10055582](https://www.healdatafair.org/app-search?data=10055582)

My console log is showing the following error: `ReferenceError: repo_repository_name is not defined`

I haven't tested locally but this should fix the reference error.