### PR TITLE
Vertical tab link option

### DIFF
--- a/components/elements/side-tab-menu.js
+++ b/components/elements/side-tab-menu.js
@@ -1,28 +1,62 @@
 import { styled } from "@mui/material/styles"
 import { Box } from "@mui/material"
+import { OpenInNew } from "@mui/icons-material"
 
-export const Block = ({ title, onClick, isSelected, index }) => {
+const getBlockStyles = ({ isSelected }) => ({
+  fontSize: "1.1rem",
+  fontWeight: "500",
+  textAlign: "start",
+  marginBottom: "15px",
+  padding: "1rem 15px",
+  background: isSelected
+    ? "linear-gradient(315deg, transparent 17px, rgba(83, 37, 101, 1) 0)"
+    : "linear-gradient(315deg, transparent 17px, rgb(229, 224, 231) 0)",
+  cursor: "pointer",
+  color: isSelected ? "#fff" : "rgba(83, 37, 101, 1)",
+})
+
+export const Block = ({ title, url, onClick, isSelected, index }) => {
+  return !url ? (
+    <Tab
+      title={title}
+      index={index}
+      isSelected={isSelected}
+      onClick={onClick}
+    />
+  ) : (
+    <LinkTab title={title} url={url} />
+  )
+}
+
+const Tab = ({ title, onClick, isSelected, index }) => {
   return (
     <button
       role="tab"
       aria-controls={`tabpanel-${index}`}
-      style={{
-        fontSize: "1.1rem",
-        fontWeight: "500",
-        textAlign: "start",
-        marginBottom: "15px",
-        padding: "1rem 15px",
-        background: isSelected
-          ? "linear-gradient(315deg, transparent 17px, rgba(83, 37, 101, 1) 0)"
-          : "linear-gradient(315deg, transparent 17px, rgb(229, 224, 231) 0)",
-        cursor: "pointer",
-        color: isSelected ? "#fff" : "rgba(83, 37, 101, 1)",
-      }}
+      style={getBlockStyles({ isSelected })}
       className={"sensitive-data-blocks"}
       onClick={onClick}
     >
       {title}
     </button>
+  )
+}
+
+const LinkTab = ({ title, url }) => {
+  return (
+    <a
+      style={{
+        ...getBlockStyles({ isSelected: false }),
+        display: "flex",
+      }}
+      className={"sensitive-data-blocks"}
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {title}
+      <OpenInNew />
+    </a>
   )
 }
 

--- a/components/sections/vertical-tabs.js
+++ b/components/sections/vertical-tabs.js
@@ -27,6 +27,7 @@ const VerticalTabs = ({ data }) => {
                 onClick={() => setShownContent(item)}
                 key={i + item.TabTitle}
                 title={item.TabTitle}
+                url={item.TabUrl}
                 index={i}
                 isSelected={item.TabTitle === shownContent.TabTitle}
               />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0cbaa7c7-6431-4a78-8108-7a2b4f22b36d)

Adds a new `TabUrl` field to the Strapi content-model for the `VerticalTabs` component:

![image](https://github.com/user-attachments/assets/ad532dc8-7fc4-457e-bb67-d630bf6ef51d)

Putting text in the TabUrl field will transform the "tab" into a link that opens in a new tab. It also puts an icon on the link to differentiate the tab types.