### PR TITLE
Vlmd tool responsiveness

### DIFF
--- a/components/sections/vlmd/quiz.js
+++ b/components/sections/vlmd/quiz.js
@@ -29,7 +29,7 @@ export function Quiz({
     !isQuestionUnanswered(state, currentQuestion)
 
   return (
-    <div style={{ flex: "0 0 400px" }}>
+    <div style={{ flex: "1 1 400px" }}>
       <div style={{ position: "sticky", top: 0 }}>
         <Question
           number={currentQuestionNumber + 1}

--- a/components/sections/vlmd/variable-standards.js
+++ b/components/sections/vlmd/variable-standards.js
@@ -396,7 +396,7 @@ const VariableStandards = () => {
         <Divider />
 
         <div
-          style={{ flex: "1 1 400px" }}
+          style={{ flex: "1 1 400px", position: "relative" }}
           aria-labelledby="variable-standards"
           role="tabpanel"
           id={
@@ -405,26 +405,30 @@ const VariableStandards = () => {
               : undefined
           }
         >
-          {openedStandard === null ? (
-            <p style={{ fontStyle: "italic" }}>
-              Please click on a standard to view more information.
-            </p>
-          ) : (
-            <>
-              <h2 style={{ fontSize: "1.3em", fontWeight: "600" }}>
-                {openedStandard.name}
-              </h2>
-              {openedStandard.link && (
-                <Link to={openedStandard.link}>
-                  Visit website{" "}
-                  <OpenInNew
-                    sx={{ fontSize: "1em", transform: "translateY(-1px)" }}
-                  />
-                </Link>
-              )}
-              <p style={{ marginTop: "1rem" }}>{openedStandard.description}</p>
-            </>
-          )}
+          <div className="py-4 sticky top-0">
+            {openedStandard === null ? (
+              <p style={{ fontStyle: "italic" }}>
+                Please click on a standard to view more information.
+              </p>
+            ) : (
+              <>
+                <h2 style={{ fontSize: "1.3em", fontWeight: "600" }}>
+                  {openedStandard.name}
+                </h2>
+                {openedStandard.link && (
+                  <Link to={openedStandard.link}>
+                    Visit website{" "}
+                    <OpenInNew
+                      sx={{ fontSize: "1em", transform: "translateY(-1px)" }}
+                    />
+                  </Link>
+                )}
+                <p style={{ marginTop: "1rem" }}>
+                  {openedStandard.description}
+                </p>
+              </>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/components/sections/vlmd/variable-standards.js
+++ b/components/sections/vlmd/variable-standards.js
@@ -396,7 +396,7 @@ const VariableStandards = () => {
         <Divider />
 
         <div
-          style={{ flex: "0 0 400px" }}
+          style={{ flex: "1 1 400px" }}
           aria-labelledby="variable-standards"
           role="tabpanel"
           id={


### PR DESCRIPTION
Addresses cutoff on slightly smaller screens in the vlmd tool
_Note that this isn't meant to address a mobile view_

| from this | to this |
| - | - |
| ![HEAL VSF tool cut off](https://github.com/user-attachments/assets/962a3495-a39a-424b-8d74-068c67cf09d4) | ![image](https://github.com/user-attachments/assets/12a6e23c-fed1-421d-9187-3078607ad0ba) |

--- 

Bonus: makes the right sidebar sticky to match the left one
![image](https://github.com/user-attachments/assets/d1e8f0b8-b66c-4077-819e-fa31c13b8aeb)
