### PR TITLE
Feature/vertical tabs with accordion

### DIFF
--- a/components/elements/accordion.js
+++ b/components/elements/accordion.js
@@ -5,8 +5,14 @@ import MuiAccordionSummary from "@mui/material/AccordionSummary"
 import MuiAccordionDetails from "@mui/material/AccordionDetails"
 import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp"
 
-export const Accordion = styled((props) => (
-  <MuiAccordion disableGutters elevation={0} square {...props} />
+export const Accordion = styled(({ onChange, ...props }) => (
+  <MuiAccordion
+    disableGutters
+    elevation={0}
+    square
+    onChange={(event, expanded) => onChange?.(event, expanded)}
+    {...props}
+  />
 ))(({ theme }) => ({
   "&:not(:last-child)": {
     borderBottom: 0,

--- a/components/elements/accordion.js
+++ b/components/elements/accordion.js
@@ -51,7 +51,7 @@ export const AccordionSummary = styled((props) => (
 // the wrap styles below ensure that long urls don't cause the accordion
 // container to extend past the edge of the page container
 export const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
-  border: "none",
+  border: "1px solid #e5e0e7",
   color: "#532565",
   wordWrap: "break-word",
   overflowWrap: "break-word",
@@ -59,4 +59,5 @@ export const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   p: {
     fontSize: "0.95rem",
   },
+  backgroundColor: "#fff",
 }))

--- a/components/elements/accordion.js
+++ b/components/elements/accordion.js
@@ -5,26 +5,33 @@ import MuiAccordionSummary from "@mui/material/AccordionSummary"
 import MuiAccordionDetails from "@mui/material/AccordionDetails"
 import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp"
 
-export const Accordion = styled(({ onChange, ...props }) => (
-  <MuiAccordion
-    disableGutters
-    elevation={0}
-    square
-    onChange={(event, expanded) => onChange?.(event, expanded)}
-    {...props}
-  />
-))(({ theme }) => ({
-  "&:not(:last-child)": {
-    borderBottom: 0,
-  },
-  background: "linear-gradient(315deg, transparent 17px, #e5e0e7 0)",
-  marginBottom: "1rem",
-  "& .MuiAccordionSummary-root": {
-    padding: "0.25rem 1rem",
-    display: "flex",
-    justifyContent: "space-between",
-  },
-}))
+export const Accordion = React.memo(
+  styled(
+    React.forwardRef(function AccordionFwd(props, ref) {
+      console.log("[Accordion render]", props.expanded) // see which ones re-render
+      return (
+        <MuiAccordion
+          ref={ref}
+          disableGutters
+          elevation={0}
+          square
+          {...props}
+        />
+      )
+    })
+  )(({ theme }) => ({
+    "&:not(:last-child)": {
+      borderBottom: 0,
+    },
+    background: "linear-gradient(315deg, transparent 17px, #e5e0e7 0)",
+    marginBottom: "1rem",
+    "& .MuiAccordionSummary-root": {
+      padding: "0.25rem 1rem",
+      display: "flex",
+      justifyContent: "space-between",
+    },
+  }))
+)
 
 export const AccordionSummary = styled((props) => (
   <MuiAccordionSummary
@@ -54,8 +61,6 @@ export const AccordionSummary = styled((props) => (
   },
 }))
 
-// the wrap styles below ensure that long urls don't cause the accordion
-// container to extend past the edge of the page container
 export const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   border: "1px solid #e5e0e7",
   color: "#532565",

--- a/components/elements/accordion/accordion-controls.js
+++ b/components/elements/accordion/accordion-controls.js
@@ -1,0 +1,38 @@
+import { Box, Button } from "@mui/material"
+
+export const AccordionControls = ({
+  expandedStates,
+  onExpandAll,
+  onCollapseAll,
+}) => (
+  <Box
+    sx={{
+      display: "flex",
+      gap: 1,
+      mb: "1rem",
+      justifyContent: "flex-end",
+      flexWrap: "wrap",
+    }}
+  >
+    <Button
+      variant="outlined"
+      size="medium"
+      sx={{ minHeight: 40 }}
+      onClick={onExpandAll}
+      disabled={expandedStates.every(Boolean)}
+    >
+      Expand All
+    </Button>
+    <Button
+      variant="outlined"
+      size="medium"
+      sx={{ minHeight: 40 }}
+      onClick={onCollapseAll}
+      disabled={expandedStates.every((state) => !state)}
+    >
+      Collapse All
+    </Button>
+  </Box>
+)
+
+export default AccordionControls

--- a/components/elements/accordion/accordion-list.js
+++ b/components/elements/accordion/accordion-list.js
@@ -1,0 +1,33 @@
+import { Typography } from "@mui/material"
+import { Accordion, AccordionSummary, AccordionDetails } from "./"
+import Markdown from "../markdown"
+
+export const AccordionList = ({ sections, expandedStates, handleToggle }) => (
+  <div>
+    {sections.map((section, index) => (
+      <Accordion
+        key={index}
+        id={`accordion-${index}`}
+        expanded={!!expandedStates[index]}
+        onChange={(e, isExpanded) => handleToggle(index, isExpanded)}
+        sx={{ width: "100%", mb: 1 }}
+      >
+        <AccordionSummary>
+          <Typography
+            variant="h3"
+            sx={{
+              fontSize: { xs: "1rem", sm: "1.25rem", md: "1.5rem" },
+            }}
+          >
+            {section.title}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Markdown>{section.content}</Markdown>
+        </AccordionDetails>
+      </Accordion>
+    ))}
+  </div>
+)
+
+export default AccordionList

--- a/components/elements/accordion/accordion.js
+++ b/components/elements/accordion/accordion.js
@@ -8,7 +8,7 @@ import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp"
 export const Accordion = React.memo(
   styled(
     React.forwardRef(function AccordionFwd(props, ref) {
-      console.log("[Accordion render]", props.expanded) // see which ones re-render
+      console.log("[Accordion render]", props.expanded)
       return (
         <MuiAccordion
           ref={ref}

--- a/components/elements/accordion/accordion.js
+++ b/components/elements/accordion/accordion.js
@@ -8,7 +8,6 @@ import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp"
 export const Accordion = React.memo(
   styled(
     React.forwardRef(function AccordionFwd(props, ref) {
-      console.log("[Accordion render]", props.expanded)
       return (
         <MuiAccordion
           ref={ref}

--- a/components/elements/accordion/index.js
+++ b/components/elements/accordion/index.js
@@ -1,0 +1,3 @@
+export * from "./accordion"
+export * from "./accordion-list"
+export * from "./accordion-controls"

--- a/components/route-guard.js
+++ b/components/route-guard.js
@@ -62,7 +62,7 @@ function RouteGuard({ children }) {
       "/resources/metadata/finder",
       "/repository-decision-tree",
       "/resources/sensitive-data",
-      "/test/resources/data-sharing-success",
+      "/resources/data-sharing-success",
       // The following used to be private pages only exposed to signed in guests
       // "/directory",
       // "/collaboration",

--- a/components/route-guard.js
+++ b/components/route-guard.js
@@ -62,6 +62,7 @@ function RouteGuard({ children }) {
       "/resources/metadata/finder",
       "/repository-decision-tree",
       "/resources/sensitive-data",
+      "/test/resources/data-sharing-success",
       // The following used to be private pages only exposed to signed in guests
       // "/directory",
       // "/collaboration",

--- a/components/route-guard.js
+++ b/components/route-guard.js
@@ -47,7 +47,7 @@ function RouteGuard({ children }) {
       "/faqs",
       "/glossary",
       "/webinar",
-      "/search",
+      // "/search",
       "/collective/meetings",
       "/resources/metadata",
       "/resources/repositories",

--- a/components/sections.js
+++ b/components/sections.js
@@ -47,6 +47,7 @@ import Footnotes from "./sections/footnotes"
 import ChecklistGraphic from "./sections/checklist-graphic/checklist-graphic"
 import HeroButton from "./sections/hero-button"
 import DataSharingStatus from "./sections/data-sharing-status"
+import VerticalTabsWithAccordion from "./sections/vertical-tabs-with-accordion"
 
 // Map Strapi sections to section components
 const sectionComponents = {
@@ -98,6 +99,7 @@ const sectionComponents = {
   "sections.checklist-graphic": ChecklistGraphic,
   "sections.hero-button": HeroButton,
   "elements.data-sharing-status": DataSharingStatus,
+  "sections.vertical-tabs-with-accordion": VerticalTabsWithAccordion,
 }
 
 // Display a section individually

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -128,7 +128,9 @@ const VerticalTabsWithAccordion = ({ data }) => {
               </div>
             </>
           ) : (
-            <Markdown>{sections[0]?.content}</Markdown>
+            <div style={{ color: "#532565" }}>
+              <Markdown>{sections[0]?.content}</Markdown>
+            </div>
           )}
         </PanelContainer>
       </div>

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -204,7 +204,7 @@ function parseMarkdownToSections(markdown) {
   let foundFirstHeading = false
 
   for (const line of lines) {
-    const h1Match = line.match(/^# (.*)/)
+    const h1Match = line.match(/^\s{0,3}# (.+?)(?:\s+#+)?$/)
     if (h1Match) {
       foundFirstHeading = true
       if (currentTitle) {

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -4,18 +4,13 @@ import {
   Typography,
   Divider,
   Box,
-  Button,
   useMediaQuery,
   MenuItem,
   Select,
   Fab,
 } from "@mui/material"
 import { KeyboardArrowUp, KeyboardArrowDown } from "@mui/icons-material"
-import {
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-} from "../elements/accordion"
+import { AccordionControls, AccordionList } from "../elements/accordion"
 import {
   Block,
   ButtonBlockContainer,
@@ -165,62 +160,16 @@ const VerticalTabsWithAccordion = ({ data }) => {
 
           {sections[0]?.type === "accordion" ? (
             <>
-              <Box
-                sx={{
-                  display: "flex",
-                  gap: 1,
-                  marginBottom: "1rem",
-                  justifyContent: "flex-end",
-                  flexWrap: "wrap",
-                }}
-              >
-                <Button
-                  variant="outlined"
-                  size="medium"
-                  sx={{ minHeight: 40 }}
-                  onClick={handleExpandAll}
-                  disabled={expandedStates.every(Boolean)}
-                >
-                  Expand All
-                </Button>
-                <Button
-                  variant="outlined"
-                  size="medium"
-                  sx={{ minHeight: 40 }}
-                  onClick={handleCollapseAll}
-                  disabled={expandedStates.every((state) => !state)}
-                >
-                  Collapse All
-                </Button>
-              </Box>
-
-              <div>
-                {sections.map((section, index) => (
-                  <Accordion
-                    key={index}
-                    id={`accordion-${index}`}
-                    expanded={!!expandedStates[index]}
-                    onChange={(e, isExpanded) =>
-                      handleToggle(index, isExpanded)
-                    }
-                    sx={{ width: "100%", marginBottom: 1 }}
-                  >
-                    <AccordionSummary>
-                      <Typography
-                        variant="h3"
-                        sx={{
-                          fontSize: { xs: "1rem", sm: "1.25rem", md: "1.5rem" },
-                        }}
-                      >
-                        {section.title}
-                      </Typography>
-                    </AccordionSummary>
-                    <AccordionDetails>
-                      <Markdown>{section.content}</Markdown>
-                    </AccordionDetails>
-                  </Accordion>
-                ))}
-              </div>
+              <AccordionControls
+                expandedStates={expandedStates}
+                onExpandAll={handleExpandAll}
+                onCollapseAll={handleCollapseAll}
+              />
+              <AccordionList
+                sections={sections}
+                expandedStates={expandedStates}
+                handleToggle={handleToggle}
+              />
             </>
           ) : (
             <div style={{ color: "#532565" }}>

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -17,6 +17,7 @@ import {
   PanelContainer,
 } from "../elements/side-tab-menu"
 import { useTheme } from "@mui/material/styles"
+import parseMarkdownToSections from "../../utils/parse-markdown-to-sections"
 
 const VerticalTabsWithAccordion = ({ data }) => {
   const theme = useTheme()
@@ -42,6 +43,7 @@ const VerticalTabsWithAccordion = ({ data }) => {
   }, [shownContent, sections])
 
   // Scroll listener for Back to Top button
+  // To Do: add this to page layout component to implement site-wide
   useEffect(() => {
     const handleScroll = () => setShowBackToTop(window.scrollY > 200)
     window.addEventListener("scroll", handleScroll)
@@ -194,45 +196,3 @@ const VerticalTabsWithAccordion = ({ data }) => {
 }
 
 export default VerticalTabsWithAccordion
-
-function parseMarkdownToSections(markdown) {
-  const lines = markdown.split("\n")
-  const sections = []
-
-  let currentTitle = ""
-  let currentContent = []
-  let foundFirstHeading = false
-
-  for (const line of lines) {
-    const h1Match = line.match(/^\s{0,3}# (.+?)(?:\s+#+)?$/)
-    if (h1Match) {
-      foundFirstHeading = true
-      if (currentTitle) {
-        sections.push({
-          type: "accordion",
-          title: currentTitle,
-          content: currentContent.join("\n").trim(),
-        })
-        currentContent = []
-      }
-      currentTitle = h1Match[1].trim()
-    } else {
-      currentContent.push(line)
-    }
-  }
-
-  if (currentTitle) {
-    sections.push({
-      type: "accordion",
-      title: currentTitle,
-      content: currentContent.join("\n").trim(),
-    })
-  } else if (currentContent.length && !foundFirstHeading) {
-    sections.push({
-      type: "text",
-      content: currentContent.join("\n").trim(),
-    })
-  }
-
-  return sections
-}

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -8,7 +8,9 @@ import {
   useMediaQuery,
   MenuItem,
   Select,
+  Fab,
 } from "@mui/material"
+import { KeyboardArrowUp } from "@mui/icons-material"
 import {
   Accordion,
   AccordionSummary,
@@ -28,13 +30,13 @@ const VerticalTabsWithAccordion = ({ data }) => {
   const [shownContent, setShownContent] = useState(
     () => data.TabItemWithAccordion[0]
   )
+  const [expandedStates, setExpandedStates] = useState([])
+  const [showBackToTop, setShowBackToTop] = useState(false)
 
   const sections = useMemo(
     () => parseMarkdownToSections(shownContent.TabContent),
     [shownContent.TabContent]
   )
-
-  const [expandedStates, setExpandedStates] = useState([])
 
   useEffect(() => {
     setExpandedStates(
@@ -44,13 +46,17 @@ const VerticalTabsWithAccordion = ({ data }) => {
     )
   }, [shownContent, sections])
 
-  const handleExpandAll = () => {
-    setExpandedStates(Array(sections.length).fill(true))
-  }
+  // Scroll listener for Back to Top button
+  useEffect(() => {
+    const handleScroll = () => setShowBackToTop(window.scrollY > 200)
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
 
-  const handleCollapseAll = () => {
+  const handleExpandAll = () =>
+    setExpandedStates(Array(sections.length).fill(true))
+  const handleCollapseAll = () =>
     setExpandedStates(Array(sections.length).fill(false))
-  }
 
   const handleToggle = (index, isExpanded) => {
     setExpandedStates((prev) => {
@@ -196,6 +202,17 @@ const VerticalTabsWithAccordion = ({ data }) => {
           )}
         </PanelContainer>
       </div>
+
+      {showBackToTop && (
+        <Fab
+          color="primary"
+          size="medium"
+          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          sx={{ position: "fixed", bottom: 16, right: 16, zIndex: 1000 }}
+        >
+          <KeyboardArrowUp />
+        </Fab>
+      )}
     </div>
   )
 }

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from "react"
+import React, { useState, useEffect, useMemo, Fragment } from "react"
 import Markdown from "../elements/markdown"
 import {
   Typography,
@@ -10,7 +10,7 @@ import {
   Select,
   Fab,
 } from "@mui/material"
-import { KeyboardArrowUp } from "@mui/icons-material"
+import { KeyboardArrowUp, KeyboardArrowDown } from "@mui/icons-material"
 import {
   Accordion,
   AccordionSummary,
@@ -87,10 +87,31 @@ const VerticalTabsWithAccordion = ({ data }) => {
                 )
                 setShownContent(selected)
               }}
+              IconComponent={KeyboardArrowDown}
+              renderValue={(selected) => (
+                <Typography
+                  variant="h2"
+                  color="primary"
+                  sx={{
+                    fontWeight: 600,
+                    paddingBottom: "0 !important",
+                  }}
+                >
+                  {selected}
+                </Typography>
+              )}
+              sx={{
+                border: "1px solid #982568",
+                "& .MuiSelect-icon": {
+                  color: "#532565",
+                  right: "1rem",
+                  fontSize: "3rem",
+                },
+              }}
             >
               {data.TabItemWithAccordion.map((item) => (
                 <MenuItem key={item.TabTitle} value={item.TabTitle}>
-                  {item.TabTitle}
+                  <Typography variant="body1">{item.TabTitle}</Typography>
                 </MenuItem>
               ))}
             </Select>
@@ -123,18 +144,24 @@ const VerticalTabsWithAccordion = ({ data }) => {
             marginTop: isMobile ? 2 : 0,
           }}
         >
-          <Typography
-            variant="h2"
-            color="primary"
-            sx={{
-              fontWeight: 600,
-              paddingTop: 0,
-              fontSize: { xs: "1.5rem", sm: "2rem", md: "2.5rem" },
-            }}
-          >
-            {shownContent.TabTitle}
-          </Typography>
-          <Divider sx={{ backgroundColor: "#982568", marginBottom: "1rem" }} />
+          {!isMobile && (
+            <Fragment>
+              <Typography
+                variant="h2"
+                color="primary"
+                sx={{
+                  fontWeight: 600,
+                  paddingTop: 0,
+                  fontSize: { xs: "1.5rem", sm: "2rem", md: "2.5rem" },
+                }}
+              >
+                {shownContent.TabTitle}
+              </Typography>
+              <Divider
+                sx={{ backgroundColor: "#982568", marginBottom: "1rem" }}
+              />
+            </Fragment>
+          )}
 
           {sections[0]?.type === "accordion" ? (
             <>

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react"
+import React, { useState, useEffect, useMemo } from "react"
 import Markdown from "../elements/markdown"
 import { Typography, Divider, Box, Button } from "@mui/material"
 import {
@@ -13,9 +13,14 @@ import {
 } from "../elements/side-tab-menu"
 
 const VerticalTabsWithAccordion = ({ data }) => {
-  const [shownContent, setShownContent] = useState(data.TabItemWithAccordion[0])
+  const [shownContent, setShownContent] = useState(
+    () => data.TabItemWithAccordion[0]
+  )
 
-  const sections = parseMarkdownToSections(shownContent.TabContent)
+  const sections = useMemo(
+    () => parseMarkdownToSections(shownContent.TabContent),
+    [shownContent.TabContent]
+  )
 
   const [expandedStates, setExpandedStates] = useState([])
 
@@ -135,17 +140,16 @@ export default VerticalTabsWithAccordion
 
 function parseMarkdownToSections(markdown) {
   const lines = markdown.split("\n")
-  if (!lines[0].match(/^# /)) {
-    return [{ type: "text", content: markdown.trim() }]
-  }
-
   const sections = []
+
   let currentTitle = ""
   let currentContent = []
+  let foundFirstHeading = false
 
   for (const line of lines) {
     const h1Match = line.match(/^# (.*)/)
     if (h1Match) {
+      foundFirstHeading = true
       if (currentTitle) {
         sections.push({
           type: "accordion",
@@ -164,6 +168,11 @@ function parseMarkdownToSections(markdown) {
     sections.push({
       type: "accordion",
       title: currentTitle,
+      content: currentContent.join("\n").trim(),
+    })
+  } else if (currentContent.length && !foundFirstHeading) {
+    sections.push({
+      type: "text",
       content: currentContent.join("\n").trim(),
     })
   }

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -1,0 +1,172 @@
+import React, { useState, useEffect } from "react"
+import Markdown from "../elements/markdown"
+import { Typography, Divider, Box, Button } from "@mui/material"
+import {
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+} from "../elements/accordion"
+import {
+  Block,
+  ButtonBlockContainer,
+  PanelContainer,
+} from "../elements/side-tab-menu"
+
+const VerticalTabsWithAccordion = ({ data }) => {
+  const [shownContent, setShownContent] = useState(data.TabItemWithAccordion[0])
+
+  const sections = parseMarkdownToSections(shownContent.TabContent)
+
+  const [expandedStates, setExpandedStates] = useState([])
+
+  useEffect(() => {
+    setExpandedStates(
+      sections[0]?.type === "accordion"
+        ? Array(sections.length).fill(false)
+        : []
+    )
+  }, [shownContent, sections])
+
+  const handleExpandAll = () => {
+    setExpandedStates(Array(sections.length).fill(true))
+  }
+
+  const handleCollapseAll = () => {
+    setExpandedStates(Array(sections.length).fill(false))
+  }
+
+  const handleToggle = (index, isExpanded) => {
+    setExpandedStates((prev) => {
+      const next = [...prev]
+      next[index] = typeof isExpanded === "boolean" ? isExpanded : !prev[index]
+      return next
+    })
+  }
+
+  return (
+    <div className="container pb-12">
+      <div style={{ display: "flex", justifyContent: "space-between" }}>
+        <ButtonBlockContainer
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "stretch",
+            flex: { md: "0 0 300px", sm: "0 0 200px" },
+          }}
+        >
+          {data.TabItemWithAccordion.map((item, i) => (
+            <Block
+              onClick={() => setShownContent(item)}
+              key={i + item.TabTitle}
+              title={item.TabTitle}
+              index={i}
+              isSelected={item.TabTitle === shownContent.TabTitle}
+            />
+          ))}
+        </ButtonBlockContainer>
+
+        <PanelContainer>
+          <Typography
+            variant="h2"
+            color="primary"
+            sx={{ fontWeight: "600", paddingTop: 0 }}
+          >
+            {shownContent.TabTitle}
+          </Typography>
+          <Divider sx={{ backgroundColor: "#982568", marginBottom: "1rem" }} />
+
+          {sections[0]?.type === "accordion" ? (
+            <>
+              <Box
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  marginBottom: "1rem",
+                  justifyContent: "flex-end",
+                }}
+              >
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={handleExpandAll}
+                  disabled={expandedStates.every(Boolean)}
+                >
+                  Expand All
+                </Button>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  onClick={handleCollapseAll}
+                  disabled={expandedStates.every((state) => !state)}
+                >
+                  Collapse All
+                </Button>
+              </Box>
+
+              <div>
+                {sections.map((section, index) => (
+                  <Accordion
+                    key={index}
+                    expanded={!!expandedStates[index]}
+                    onChange={(e, isExpanded) =>
+                      handleToggle(index, isExpanded)
+                    }
+                  >
+                    <AccordionSummary>
+                      <Typography variant="h3">{section.title}</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails>
+                      <Markdown>{section.content}</Markdown>
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
+              </div>
+            </>
+          ) : (
+            <Markdown>{sections[0]?.content}</Markdown>
+          )}
+        </PanelContainer>
+      </div>
+    </div>
+  )
+}
+
+export default VerticalTabsWithAccordion
+
+function parseMarkdownToSections(markdown) {
+  const lines = markdown.split("\n")
+  if (!lines[0].match(/^# /)) {
+    return [{ type: "text", content: markdown.trim() }]
+  }
+
+  const sections = []
+  let currentTitle = ""
+  let currentContent = []
+
+  for (const line of lines) {
+    const h1Match = line.match(/^# (.*)/)
+    if (h1Match) {
+      if (currentTitle) {
+        sections.push({
+          type: "accordion",
+          title: currentTitle,
+          content: currentContent.join("\n").trim(),
+        })
+        currentContent = []
+      }
+      currentTitle = h1Match[1].trim()
+    } else {
+      currentContent.push(line)
+    }
+  }
+
+  if (currentTitle) {
+    sections.push({
+      type: "accordion",
+      title: currentTitle,
+      content: currentContent.join("\n").trim(),
+    })
+  }
+
+  return sections
+}

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -1,6 +1,14 @@
 import React, { useState, useEffect, useMemo } from "react"
 import Markdown from "../elements/markdown"
-import { Typography, Divider, Box, Button } from "@mui/material"
+import {
+  Typography,
+  Divider,
+  Box,
+  Button,
+  useMediaQuery,
+  MenuItem,
+  Select,
+} from "@mui/material"
 import {
   Accordion,
   AccordionSummary,
@@ -11,8 +19,12 @@ import {
   ButtonBlockContainer,
   PanelContainer,
 } from "../elements/side-tab-menu"
+import { useTheme } from "@mui/material/styles"
 
 const VerticalTabsWithAccordion = ({ data }) => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
+
   const [shownContent, setShownContent] = useState(
     () => data.TabItemWithAccordion[0]
   )
@@ -46,35 +58,73 @@ const VerticalTabsWithAccordion = ({ data }) => {
       next[index] = typeof isExpanded === "boolean" ? isExpanded : !prev[index]
       return next
     })
+
+    if (!expandedStates[index]) {
+      const el = document.getElementById(`accordion-${index}`)
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
   }
 
   return (
     <div className="container pb-12">
-      <div style={{ display: "flex", justifyContent: "space-between" }}>
-        <ButtonBlockContainer
+      <div
+        style={{ display: "flex", flexDirection: isMobile ? "column" : "row" }}
+      >
+        {isMobile ? (
+          <Box mb={2}>
+            <Select
+              fullWidth
+              value={shownContent.TabTitle}
+              onChange={(e) => {
+                const selected = data.TabItemWithAccordion.find(
+                  (item) => item.TabTitle === e.target.value
+                )
+                setShownContent(selected)
+              }}
+            >
+              {data.TabItemWithAccordion.map((item) => (
+                <MenuItem key={item.TabTitle} value={item.TabTitle}>
+                  {item.TabTitle}
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        ) : (
+          <ButtonBlockContainer
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "stretch",
+              flex: { md: "0 0 300px", sm: "0 0 200px" },
+            }}
+          >
+            {data.TabItemWithAccordion.map((item, i) => (
+              <Block
+                onClick={() => setShownContent(item)}
+                key={i + item.TabTitle}
+                title={item.TabTitle}
+                index={i}
+                isSelected={item.TabTitle === shownContent.TabTitle}
+              />
+            ))}
+          </ButtonBlockContainer>
+        )}
+
+        <PanelContainer
           sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "stretch",
-            flex: { md: "0 0 300px", sm: "0 0 200px" },
+            width: "100%",
+            paddingX: isMobile ? 2 : 0,
+            marginTop: isMobile ? 2 : 0,
           }}
         >
-          {data.TabItemWithAccordion.map((item, i) => (
-            <Block
-              onClick={() => setShownContent(item)}
-              key={i + item.TabTitle}
-              title={item.TabTitle}
-              index={i}
-              isSelected={item.TabTitle === shownContent.TabTitle}
-            />
-          ))}
-        </ButtonBlockContainer>
-
-        <PanelContainer>
           <Typography
             variant="h2"
             color="primary"
-            sx={{ fontWeight: "600", paddingTop: 0 }}
+            sx={{
+              fontWeight: 600,
+              paddingTop: 0,
+              fontSize: { xs: "1.5rem", sm: "2rem", md: "2.5rem" },
+            }}
           >
             {shownContent.TabTitle}
           </Typography>
@@ -88,11 +138,13 @@ const VerticalTabsWithAccordion = ({ data }) => {
                   gap: 1,
                   marginBottom: "1rem",
                   justifyContent: "flex-end",
+                  flexWrap: "wrap",
                 }}
               >
                 <Button
                   variant="outlined"
-                  size="small"
+                  size="medium"
+                  sx={{ minHeight: 40 }}
                   onClick={handleExpandAll}
                   disabled={expandedStates.every(Boolean)}
                 >
@@ -100,7 +152,8 @@ const VerticalTabsWithAccordion = ({ data }) => {
                 </Button>
                 <Button
                   variant="outlined"
-                  size="small"
+                  size="medium"
+                  sx={{ minHeight: 40 }}
                   onClick={handleCollapseAll}
                   disabled={expandedStates.every((state) => !state)}
                 >
@@ -112,13 +165,22 @@ const VerticalTabsWithAccordion = ({ data }) => {
                 {sections.map((section, index) => (
                   <Accordion
                     key={index}
+                    id={`accordion-${index}`}
                     expanded={!!expandedStates[index]}
                     onChange={(e, isExpanded) =>
                       handleToggle(index, isExpanded)
                     }
+                    sx={{ width: "100%", marginBottom: 1 }}
                   >
                     <AccordionSummary>
-                      <Typography variant="h3">{section.title}</Typography>
+                      <Typography
+                        variant="h3"
+                        sx={{
+                          fontSize: { xs: "1rem", sm: "1.25rem", md: "1.5rem" },
+                        }}
+                      >
+                        {section.title}
+                      </Typography>
                     </AccordionSummary>
                     <AccordionDetails>
                       <Markdown>{section.content}</Markdown>

--- a/styles/index.css
+++ b/styles/index.css
@@ -43,6 +43,10 @@ html {
   }
 }
 
+strong {
+  font-weight: 600;
+}
+
 .sensitive-data-blocks:hover {
   background: linear-gradient(315deg, transparent 17px, rgba(83, 37, 101, 1) 0) !important;
   color: white !important;

--- a/utils/parse-markdown-to-sections.js
+++ b/utils/parse-markdown-to-sections.js
@@ -1,0 +1,70 @@
+/**
+ * parseMarkdownToSections
+ * --------------------------------------------
+ * Converts raw markdown into structured sections for rendering
+ * using a reduce-based functional approach.
+ *
+ * @param {string} markdown - Raw markdown string from Strapi
+ * @returns {Array} sections - Array of objects:
+ *   [
+ *     { type: "accordion", title: string, content: string },
+ *     { type: "text", content: string }
+ *   ]
+ */
+
+const parseMarkdownToSections = (markdown) => {
+  const { sections, current } = markdown.split("\n").reduce(
+    (acc, line) => {
+      let { sections, current } = acc
+
+      if (isHeading(line)) {
+        // Push the previous section if it exists
+        if (current) sections.push(finalizeSection(current))
+        current = startAccordionSection(line)
+      } else {
+        // Start a text section if nothing exists yet
+        if (!current) current = startTextSection()
+        current.content.push(line)
+      }
+
+      return { sections, current }
+    },
+    { sections: [], current: null }
+  )
+
+  // Push the last section if exists
+  return current ? [...sections, finalizeSection(current)] : sections
+}
+
+// --- Helper functions ---
+
+/**
+ * Check if a line is a Markdown H1 heading.
+ * Matches strings like "# Title" or "# Title ###".
+ */
+const isHeading = (line) =>
+  /^\s{0,3}# (.+?)(?:\s+#+)?$/.test(line)
+
+/**
+ * Create a new accordion section starting at a heading line.
+ * Extracts the heading text and initializes an empty content array.
+ */
+const startAccordionSection = (line) => {
+  const title = line.replace(/^\s{0,3}# (.+?)(?:\s+#+)?$/, "$1").trim()
+  return { type: "accordion", title, content: [] }
+}
+
+/**
+ * Create a new text-only section (used when no headings are found).
+ */
+const startTextSection = () => ({ type: "text", content: [] })
+
+/**
+ * Finalize a section by joining its content lines into a single string.
+ */
+const finalizeSection = (section) => ({
+  ...section,
+  content: section.content.join("\n").trim(),
+})
+
+export default parseMarkdownToSections


### PR DESCRIPTION
This PR adds a component called `VerticalTabsWithAccordion` to strapi. It combines the `VerticalTabs` component with the `Accordion` component. Due to limitations of nested repeatable components, the `Accordion` functionality is accomplished by searching for `H1`'s in the markdown and turning them into the `AccordionSummary` heading and the text underneath is placed in the `AccordionDetails` component. If, someday, Strapi allows for an additional level of repeatable components inside a repeatable component, this component could be improved in favor of a better editor experience.

The published page with this component can be previewed here: https://feature-vertical-tabs-with-accordion.d1mcdngnks37uk.amplifyapp.com/resources/data-sharing-success