### PR TITLE
Staging: Add VerticalTabsWithAccordion on Data Sharing Throughout the Research Lifecycle page

### DIFF
--- a/components/elements/accordion/accordion-controls.js
+++ b/components/elements/accordion/accordion-controls.js
@@ -1,0 +1,38 @@
+import { Box, Button } from "@mui/material"
+
+export const AccordionControls = ({
+  expandedStates,
+  onExpandAll,
+  onCollapseAll,
+}) => (
+  <Box
+    sx={{
+      display: "flex",
+      gap: 1,
+      mb: "1rem",
+      justifyContent: "flex-end",
+      flexWrap: "wrap",
+    }}
+  >
+    <Button
+      variant="outlined"
+      size="medium"
+      sx={{ minHeight: 40 }}
+      onClick={onExpandAll}
+      disabled={expandedStates.every(Boolean)}
+    >
+      Expand All
+    </Button>
+    <Button
+      variant="outlined"
+      size="medium"
+      sx={{ minHeight: 40 }}
+      onClick={onCollapseAll}
+      disabled={expandedStates.every((state) => !state)}
+    >
+      Collapse All
+    </Button>
+  </Box>
+)
+
+export default AccordionControls

--- a/components/elements/accordion/accordion-list.js
+++ b/components/elements/accordion/accordion-list.js
@@ -1,0 +1,33 @@
+import { Typography } from "@mui/material"
+import { Accordion, AccordionSummary, AccordionDetails } from "./"
+import Markdown from "../markdown"
+
+export const AccordionList = ({ sections, expandedStates, handleToggle }) => (
+  <div>
+    {sections.map((section, index) => (
+      <Accordion
+        key={index}
+        id={`accordion-${index}`}
+        expanded={!!expandedStates[index]}
+        onChange={(e, isExpanded) => handleToggle(index, isExpanded)}
+        sx={{ width: "100%", mb: 1 }}
+      >
+        <AccordionSummary>
+          <Typography
+            variant="h3"
+            sx={{
+              fontSize: { xs: "1rem", sm: "1.25rem", md: "1.5rem" },
+            }}
+          >
+            {section.title}
+          </Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <Markdown>{section.content}</Markdown>
+        </AccordionDetails>
+      </Accordion>
+    ))}
+  </div>
+)
+
+export default AccordionList

--- a/components/elements/accordion/accordion.js
+++ b/components/elements/accordion/accordion.js
@@ -5,20 +5,32 @@ import MuiAccordionSummary from "@mui/material/AccordionSummary"
 import MuiAccordionDetails from "@mui/material/AccordionDetails"
 import ArrowForwardIosSharpIcon from "@mui/icons-material/ArrowForwardIosSharp"
 
-export const Accordion = styled((props) => (
-  <MuiAccordion disableGutters elevation={0} square {...props} />
-))(({ theme }) => ({
-  "&:not(:last-child)": {
-    borderBottom: 0,
-  },
-  background: "linear-gradient(315deg, transparent 17px, #e5e0e7 0)",
-  marginBottom: "1rem",
-  "& .MuiAccordionSummary-root": {
-    padding: "0.25rem 1rem",
-    display: "flex",
-    justifyContent: "space-between",
-  },
-}))
+export const Accordion = React.memo(
+  styled(
+    React.forwardRef(function AccordionFwd(props, ref) {
+      return (
+        <MuiAccordion
+          ref={ref}
+          disableGutters
+          elevation={0}
+          square
+          {...props}
+        />
+      )
+    })
+  )(({ theme }) => ({
+    "&:not(:last-child)": {
+      borderBottom: 0,
+    },
+    background: "linear-gradient(315deg, transparent 17px, #e5e0e7 0)",
+    marginBottom: "1rem",
+    "& .MuiAccordionSummary-root": {
+      padding: "0.25rem 1rem",
+      display: "flex",
+      justifyContent: "space-between",
+    },
+  }))
+)
 
 export const AccordionSummary = styled((props) => (
   <MuiAccordionSummary
@@ -48,10 +60,8 @@ export const AccordionSummary = styled((props) => (
   },
 }))
 
-// the wrap styles below ensure that long urls don't cause the accordion
-// container to extend past the edge of the page container
 export const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
-  border: "none",
+  border: "1px solid #e5e0e7",
   color: "#532565",
   wordWrap: "break-word",
   overflowWrap: "break-word",
@@ -59,4 +69,5 @@ export const AccordionDetails = styled(MuiAccordionDetails)(({ theme }) => ({
   p: {
     fontSize: "0.95rem",
   },
+  backgroundColor: "#fff",
 }))

--- a/components/elements/accordion/index.js
+++ b/components/elements/accordion/index.js
@@ -1,0 +1,3 @@
+export * from "./accordion"
+export * from "./accordion-list"
+export * from "./accordion-controls"

--- a/components/route-guard.js
+++ b/components/route-guard.js
@@ -47,7 +47,7 @@ function RouteGuard({ children }) {
       "/faqs",
       "/glossary",
       "/webinar",
-      "/search",
+      // "/search",
       "/collective/meetings",
       "/resources/metadata",
       "/resources/repositories",
@@ -62,6 +62,7 @@ function RouteGuard({ children }) {
       "/resources/metadata/finder",
       "/repository-decision-tree",
       "/resources/sensitive-data",
+      "/resources/data-sharing-success",
       // The following used to be private pages only exposed to signed in guests
       // "/directory",
       // "/collaboration",

--- a/components/sections.js
+++ b/components/sections.js
@@ -47,6 +47,7 @@ import Footnotes from "./sections/footnotes"
 import ChecklistGraphic from "./sections/checklist-graphic/checklist-graphic"
 import HeroButton from "./sections/hero-button"
 import DataSharingStatus from "./sections/data-sharing-status"
+import VerticalTabsWithAccordion from "./sections/vertical-tabs-with-accordion"
 
 // Map Strapi sections to section components
 const sectionComponents = {
@@ -98,6 +99,7 @@ const sectionComponents = {
   "sections.checklist-graphic": ChecklistGraphic,
   "sections.hero-button": HeroButton,
   "elements.data-sharing-status": DataSharingStatus,
+  "sections.vertical-tabs-with-accordion": VerticalTabsWithAccordion,
 }
 
 // Display a section individually

--- a/components/sections/vertical-tabs-with-accordion.js
+++ b/components/sections/vertical-tabs-with-accordion.js
@@ -1,0 +1,198 @@
+import React, { useState, useEffect, useMemo, Fragment } from "react"
+import Markdown from "../elements/markdown"
+import {
+  Typography,
+  Divider,
+  Box,
+  useMediaQuery,
+  MenuItem,
+  Select,
+  Fab,
+} from "@mui/material"
+import { KeyboardArrowUp, KeyboardArrowDown } from "@mui/icons-material"
+import { AccordionControls, AccordionList } from "../elements/accordion"
+import {
+  Block,
+  ButtonBlockContainer,
+  PanelContainer,
+} from "../elements/side-tab-menu"
+import { useTheme } from "@mui/material/styles"
+import parseMarkdownToSections from "../../utils/parse-markdown-to-sections"
+
+const VerticalTabsWithAccordion = ({ data }) => {
+  const theme = useTheme()
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"))
+
+  const [shownContent, setShownContent] = useState(
+    () => data.TabItemWithAccordion[0]
+  )
+  const [expandedStates, setExpandedStates] = useState([])
+  const [showBackToTop, setShowBackToTop] = useState(false)
+
+  const sections = useMemo(
+    () => parseMarkdownToSections(shownContent.TabContent),
+    [shownContent.TabContent]
+  )
+
+  useEffect(() => {
+    setExpandedStates(
+      sections[0]?.type === "accordion"
+        ? Array(sections.length).fill(false)
+        : []
+    )
+  }, [shownContent, sections])
+
+  // Scroll listener for Back to Top button
+  // To Do: add this to page layout component to implement site-wide
+  useEffect(() => {
+    const handleScroll = () => setShowBackToTop(window.scrollY > 200)
+    window.addEventListener("scroll", handleScroll)
+    return () => window.removeEventListener("scroll", handleScroll)
+  }, [])
+
+  const handleExpandAll = () =>
+    setExpandedStates(Array(sections.length).fill(true))
+  const handleCollapseAll = () =>
+    setExpandedStates(Array(sections.length).fill(false))
+
+  const handleToggle = (index, isExpanded) => {
+    setExpandedStates((prev) => {
+      const next = [...prev]
+      next[index] = typeof isExpanded === "boolean" ? isExpanded : !prev[index]
+      return next
+    })
+
+    if (!expandedStates[index]) {
+      const el = document.getElementById(`accordion-${index}`)
+      if (el) el.scrollIntoView({ behavior: "smooth", block: "start" })
+    }
+  }
+
+  return (
+    <div className="container pb-12">
+      <div
+        style={{ display: "flex", flexDirection: isMobile ? "column" : "row" }}
+      >
+        {isMobile ? (
+          <Box mb={2}>
+            <Select
+              fullWidth
+              value={shownContent.TabTitle}
+              onChange={(e) => {
+                const selected = data.TabItemWithAccordion.find(
+                  (item) => item.TabTitle === e.target.value
+                )
+                setShownContent(selected)
+              }}
+              IconComponent={KeyboardArrowDown}
+              renderValue={(selected) => (
+                <Typography
+                  variant="h2"
+                  color="primary"
+                  sx={{
+                    fontWeight: 600,
+                    paddingBottom: "0 !important",
+                  }}
+                >
+                  {selected}
+                </Typography>
+              )}
+              sx={{
+                border: "1px solid #982568",
+                "& .MuiSelect-icon": {
+                  color: "#532565",
+                  right: "1rem",
+                  fontSize: "3rem",
+                },
+              }}
+            >
+              {data.TabItemWithAccordion.map((item) => (
+                <MenuItem key={item.TabTitle} value={item.TabTitle}>
+                  <Typography variant="body1">{item.TabTitle}</Typography>
+                </MenuItem>
+              ))}
+            </Select>
+          </Box>
+        ) : (
+          <ButtonBlockContainer
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              alignItems: "stretch",
+              flex: { md: "0 0 300px", sm: "0 0 200px" },
+            }}
+          >
+            {data.TabItemWithAccordion.map((item, i) => (
+              <Block
+                onClick={() => setShownContent(item)}
+                key={i + item.TabTitle}
+                title={item.TabTitle}
+                index={i}
+                isSelected={item.TabTitle === shownContent.TabTitle}
+              />
+            ))}
+          </ButtonBlockContainer>
+        )}
+
+        <PanelContainer
+          sx={{
+            width: "100%",
+            paddingX: isMobile ? 2 : 0,
+            marginTop: isMobile ? 2 : 0,
+          }}
+        >
+          {!isMobile && (
+            <Fragment>
+              <Typography
+                variant="h2"
+                color="primary"
+                sx={{
+                  fontWeight: 600,
+                  paddingTop: 0,
+                  fontSize: { xs: "1.5rem", sm: "2rem", md: "2.5rem" },
+                }}
+              >
+                {shownContent.TabTitle}
+              </Typography>
+              <Divider
+                sx={{ backgroundColor: "#982568", marginBottom: "1rem" }}
+              />
+            </Fragment>
+          )}
+
+          {sections[0]?.type === "accordion" ? (
+            <>
+              <AccordionControls
+                expandedStates={expandedStates}
+                onExpandAll={handleExpandAll}
+                onCollapseAll={handleCollapseAll}
+              />
+              <AccordionList
+                sections={sections}
+                expandedStates={expandedStates}
+                handleToggle={handleToggle}
+              />
+            </>
+          ) : (
+            <div style={{ color: "#532565" }}>
+              <Markdown>{sections[0]?.content}</Markdown>
+            </div>
+          )}
+        </PanelContainer>
+      </div>
+
+      {showBackToTop && (
+        <Fab
+          color="primary"
+          size="medium"
+          onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+          sx={{ position: "fixed", bottom: 16, right: 16, zIndex: 1000 }}
+        >
+          <KeyboardArrowUp />
+        </Fab>
+      )}
+    </div>
+  )
+}
+
+export default VerticalTabsWithAccordion

--- a/styles/index.css
+++ b/styles/index.css
@@ -43,6 +43,10 @@ html {
   }
 }
 
+strong {
+  font-weight: 600;
+}
+
 .sensitive-data-blocks:hover {
   background: linear-gradient(315deg, transparent 17px, rgba(83, 37, 101, 1) 0) !important;
   color: white !important;

--- a/utils/parse-markdown-to-sections.js
+++ b/utils/parse-markdown-to-sections.js
@@ -1,0 +1,70 @@
+/**
+ * parseMarkdownToSections
+ * --------------------------------------------
+ * Converts raw markdown into structured sections for rendering
+ * using a reduce-based functional approach.
+ *
+ * @param {string} markdown - Raw markdown string from Strapi
+ * @returns {Array} sections - Array of objects:
+ *   [
+ *     { type: "accordion", title: string, content: string },
+ *     { type: "text", content: string }
+ *   ]
+ */
+
+const parseMarkdownToSections = (markdown) => {
+  const { sections, current } = markdown.split("\n").reduce(
+    (acc, line) => {
+      let { sections, current } = acc
+
+      if (isHeading(line)) {
+        // Push the previous section if it exists
+        if (current) sections.push(finalizeSection(current))
+        current = startAccordionSection(line)
+      } else {
+        // Start a text section if nothing exists yet
+        if (!current) current = startTextSection()
+        current.content.push(line)
+      }
+
+      return { sections, current }
+    },
+    { sections: [], current: null }
+  )
+
+  // Push the last section if exists
+  return current ? [...sections, finalizeSection(current)] : sections
+}
+
+// --- Helper functions ---
+
+/**
+ * Check if a line is a Markdown H1 heading.
+ * Matches strings like "# Title" or "# Title ###".
+ */
+const isHeading = (line) =>
+  /^\s{0,3}# (.+?)(?:\s+#+)?$/.test(line)
+
+/**
+ * Create a new accordion section starting at a heading line.
+ * Extracts the heading text and initializes an empty content array.
+ */
+const startAccordionSection = (line) => {
+  const title = line.replace(/^\s{0,3}# (.+?)(?:\s+#+)?$/, "$1").trim()
+  return { type: "accordion", title, content: [] }
+}
+
+/**
+ * Create a new text-only section (used when no headings are found).
+ */
+const startTextSection = () => ({ type: "text", content: [] })
+
+/**
+ * Finalize a section by joining its content lines into a single string.
+ */
+const finalizeSection = (section) => ({
+  ...section,
+  content: section.content.join("\n").trim(),
+})
+
+export default parseMarkdownToSections


### PR DESCRIPTION
(Copied from [PR to Staging](https://github.com/heal-data-stewards/website/pull/164)) This PR adds a component called `VerticalTabsWithAccordion` to strapi. It combines the `VerticalTabs` component with the `Accordion` component. Due to limitations of nested repeatable components, the `Accordion` functionality is accomplished by searching for `H1`'s in the markdown and turning them into the `AccordionSummary` heading and the text underneath is placed in the `AccordionDetails` component. If, someday, Strapi allows for an additional level of repeatable components inside a repeatable component, this component could be improved in favor of a better editor experience.

The published page with this component can be previewed here: https://staging.healdatafair.org/resources/data-sharing-success