### PR TITLE
add info-table component

### DIFF
--- a/components/sections.js
+++ b/components/sections.js
@@ -48,6 +48,7 @@ import ChecklistGraphic from "./sections/checklist-graphic/checklist-graphic"
 import HeroButton from "./sections/hero-button"
 import DataSharingStatus from "./sections/data-sharing-status"
 import VerticalTabsWithAccordion from "./sections/vertical-tabs-with-accordion"
+import InfoTable from "./sections/info-table"
 
 // Map Strapi sections to section components
 const sectionComponents = {
@@ -100,6 +101,7 @@ const sectionComponents = {
   "sections.hero-button": HeroButton,
   "elements.data-sharing-status": DataSharingStatus,
   "sections.vertical-tabs-with-accordion": VerticalTabsWithAccordion,
+  "sections.info-table": InfoTable,
 }
 
 // Display a section individually

--- a/components/sections/info-table.js
+++ b/components/sections/info-table.js
@@ -1,0 +1,76 @@
+import React from "react"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+  Typography,
+} from "@mui/material"
+import Markdown from "../elements/markdown"
+import Link from "../elements/link"
+
+export default function InfoTable({ data }) {
+  const { TitleHeading, DescriptionHeading, TableRows } = data
+
+  return (
+    <div
+      style={{
+        width: "100%",
+        maxWidth: "1250px",
+        margin: "0 auto 3rem",
+        padding: "0 1rem",
+      }}
+    >
+      <TableContainer component={Paper}>
+        <Table aria-label="simple table">
+          <TableHead>
+            <TableRow>
+              <TableCell component="th" scope="row">
+                <Typography variant="h3">{TitleHeading}</Typography>
+              </TableCell>
+              <TableCell component="th" scope="row">
+                <Typography variant="h3">{DescriptionHeading}</Typography>
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {TableRows.map((row) => (
+              <TableRow key={row.Title}>
+                <TableCell component="th" scope="row">
+                  {row.optionalLink ? (
+                    <Link to={row.optionalLink}>
+                      <Typography variant="h4" sx={{ fontWeight: 600 }}>
+                        {row.Title}
+                      </Typography>
+                    </Link>
+                  ) : (
+                    <Typography
+                      variant="h4"
+                      sx={{ fontWeight: 600 }}
+                      color="primary"
+                    >
+                      {row.Title}
+                    </Typography>
+                  )}
+                </TableCell>
+                <TableCell align="left">
+                  <Markdown>{row.Description}</Markdown>
+                  {row.optionalLink && (
+                    <Link to={row.optionalLink}>
+                      <Typography variant="body2" sx={{ fontWeight: "500" }}>
+                        Read More...
+                      </Typography>
+                    </Link>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </div>
+  )
+}


### PR DESCRIPTION
This PR will add an InfoTable component to replace the BasicTable component. This component is mobile-responsive, and is structured by field on the Strapi end. Formerly, the BasicTable component was structured as JSON, which was a challenging editor experience.

Once the InfoTable component is added to each of the pages it is used on, the BasicTable component will be removed.

Before in Strapi:
<img width="947" height="490" alt="Screenshot 2025-10-03 at 4 11 12 PM" src="https://github.com/user-attachments/assets/10a1cdc6-03d2-4ae5-af00-4c95801c7091" />

After in Strapi:
<img width="946" height="701" alt="Screenshot 2025-10-03 at 4 11 29 PM" src="https://github.com/user-attachments/assets/cbf7c26c-6711-413d-9366-c649fcfda68f" />
