### PR TITLE
hydration, style, and font fixes

### DIFF
--- a/components/elements/accordion/accordion.js
+++ b/components/elements/accordion/accordion.js
@@ -29,6 +29,9 @@ export const Accordion = React.memo(
       display: "flex",
       justifyContent: "space-between",
     },
+    "& .MuiTypography-h3": {
+      margin: 0,
+    },
   }))
 )
 

--- a/components/elements/link.js
+++ b/components/elements/link.js
@@ -8,15 +8,15 @@ const InternalLink = React.forwardRef(function InternalLink(
   ref
 ) {
   return (
-    <NextLink href={ref} {...props}>
-      <MUILink
-        underline="hover"
-        sx={{ fontWeight: "600", color: "#982568" }}
-        {...props}
-      >
-        {children}
-      </MUILink>
-    </NextLink>
+    <MUILink
+      component={NextLink}
+      underline="hover"
+      sx={{ fontWeight: "600", color: "#982568" }}
+      ref={ref}
+      {...props}
+    >
+      {children}
+    </MUILink>
   )
 })
 

--- a/components/elements/webinar/webinar-item.js
+++ b/components/elements/webinar/webinar-item.js
@@ -20,8 +20,8 @@ const BlueLink = styled.a`
 export default function WebinarItem({ event, past, collective }) {
   let date = new Date(Date.parse(event.start.dateTime))
   let endDate = new Date(Date.parse(event.end.dateTime))
-  let sTime = date.toLocaleTimeString()
-  let eTime = endDate.toLocaleTimeString()
+  let sTime = date.toLocaleTimeString("en-US")
+  let eTime = endDate.toLocaleTimeString("en-US")
   let startTime = checkDaylightSavings(date)
     ? makeEasternTimeWithDaylightSavings(sTime)
     : makeEasternTime(sTime)

--- a/components/sections/Widget.jsx
+++ b/components/sections/Widget.jsx
@@ -1,33 +1,14 @@
 import { Button, Card, CardContent, CardHeader, Divider } from "@mui/material"
 import { Close as CloseIcon } from "@mui/icons-material"
 import { Popover } from "@headlessui/react"
-import { makeStyles } from "@mui/styles"
-
-const useStyles = makeStyles((theme) => ({
-  feedbackButton: {
-    transform: "rotate(-90deg) translateY(40px)",
-    transition: "transform 250ms, background-color 250ms",
-    height: "100px",
-    display: "flex",
-    alignItems: "flex-start",
-    "&:hover": {
-      transform: "rotate(-90deg) translateY(20px)",
-    },
-    color: "white",
-  },
-  feedbackPopup: {
-    transform: "translate(-2rem, -1rem)",
-  },
-}))
 
 export function Widget({ data }) {
-  const classes = useStyles()
   return (
     <Popover
       style={{ right: "-1rem", bottom: "106px", zIndex: 1000 }}
       className="fixed flex flex-col items-end"
     >
-      <Card component={Popover.Panel} className={classes.feedbackPopup}>
+      <Card component={Popover.Panel} sx={{ transform: "translate(-2rem, -1rem)" }}>
         <CardHeader
           title={data.sendFeedbackText}
           action={
@@ -61,7 +42,17 @@ export function Widget({ data }) {
       </Card>
 
       <Button
-        className={classes.feedbackButton}
+        sx={{
+          transform: "rotate(-90deg) translateY(40px)",
+          transition: "transform 250ms, background-color 250ms",
+          height: "100px",
+          display: "flex",
+          alignItems: "flex-start",
+          color: "white",
+          "&:hover": {
+            transform: "rotate(-90deg) translateY(20px)",
+          },
+        }}
         component={Popover.Button}
         variant="contained"
         color="primary"

--- a/components/sections/calendar.js
+++ b/components/sections/calendar.js
@@ -9,6 +9,11 @@ export default function Calendar(props) {
   const [events, setEvents] = useState(filterByDate(props.eventData))
   const { data: session } = useSession()
   const [loggedIn, setLoggedIn] = useState(false)
+  const [now, setNow] = useState(null)
+
+  useEffect(() => {
+    setNow(new Date())
+  }, [])
 
   useEffect(() => {
     if (session) {
@@ -53,7 +58,7 @@ export default function Calendar(props) {
               return new Date(a.start.dateTime) - new Date(b.start.dateTime)
             })
             .map((event, i) => {
-              if (new Date(event.start.dateTime) >= new Date()) {
+              if (now && new Date(event.start.dateTime) >= now) {
                 return (
                   <WebinarItem
                     key={event.subject + i}
@@ -78,7 +83,7 @@ export default function Calendar(props) {
             })
             .reverse()
             .map((event, i) => {
-              if (new Date(event.start.dateTime) <= new Date()) {
+              if (now && new Date(event.start.dateTime) <= now) {
                 return (
                   <WebinarItem
                     key={event.subject + i}

--- a/components/sections/checklist-graphic/checklist-graphic.js
+++ b/components/sections/checklist-graphic/checklist-graphic.js
@@ -3,7 +3,14 @@ import React from "react"
 import { CloudsGroup } from "./cloud-graphics"
 import { Icon } from "./icon"
 import { Text } from "./text"
-import { ArcLine, HorizontalLine, VerticalLine } from "./lines"
+import {
+  ArcLine,
+  HorizontalLine,
+  VerticalLine,
+  lineColor,
+  lineWidth,
+  iconSize,
+} from "./lines"
 import Link from "next/link"
 import { Box } from "@mui/material"
 import { ArrowForward } from "@mui/icons-material"
@@ -97,9 +104,9 @@ const ButtonHider = styled(Box)`
 `
 
 const ChecklistGrid = styled("div")`
-  --line-color: #dcd2de;
-  --line-width: 10px;
-  --icon-size: 80px;
+  --line-color: ${lineColor};
+  --line-width: ${lineWidth};
+  --icon-size: ${iconSize};
   --gutter-height: 40px;
 
   position: "absolute";

--- a/components/sections/checklist-graphic/lines.js
+++ b/components/sections/checklist-graphic/lines.js
@@ -1,3 +1,7 @@
+export const lineColor = "#dcd2de"
+export const lineWidth = "10px"
+export const iconSize = "80px"
+
 /**
  * @param {{ arcNumber: number, position: "tl" | "tr" | "bl" | "br" }}
  * @help the position is the corner wrapped by the arc segment
@@ -38,17 +42,17 @@ export function ArcLine({ arcNumber, position }) {
     >
       <div
         style={{
-          width: "var(--icon-size)",
-          height: "var(--icon-size)",
+          width: `var(--icon-size, ${iconSize})`,
+          height: `var(--icon-size, ${iconSize})`,
           position: "relative",
         }}
       >
         <div
           style={{
             position: "absolute",
-            backgroundColor: "var(--line-color)",
-            width: "calc((100% + var(--line-width)) / 2)",
-            height: "calc((100% + var(--line-width)) / 2)",
+            backgroundColor: `var(--line-color, ${lineColor})`,
+            width: `calc((100% + var(--line-width, ${lineWidth})) / 2)`,
+            height: `calc((100% + var(--line-width, ${lineWidth})) / 2)`,
             ...positionVals,
           }}
         >
@@ -56,8 +60,8 @@ export function ArcLine({ arcNumber, position }) {
             style={{
               backgroundColor: "white",
               position: "absolute",
-              width: "calc(100% - var(--line-width)",
-              height: "calc(100% - var(--line-width)",
+              width: `calc(100% - var(--line-width, ${lineWidth}))`,
+              height: `calc(100% - var(--line-width, ${lineWidth}))`,
               ...positionVals,
             }}
           ></div>

--- a/components/sections/semantic-search/components/IntegratedSearchBar.js
+++ b/components/sections/semantic-search/components/IntegratedSearchBar.js
@@ -7,7 +7,7 @@ import {
   Tooltip,
 } from "@mui/material"
 import { useRouter } from "next/router"
-import { useCallback, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { backgroundColor } from "tailwindcss/defaultTheme"
 import { QueryCacheProvider } from "utils/use-query"
 import { sendCustomEvent } from "utils/analytics"
@@ -55,20 +55,24 @@ export function IntegratedSearchBar({
 }) {
   const router = useRouter()
 
-  const path = typeof window !== "undefined" ? window.location.pathname : ""
   const searchLocation =
-    path === "/resources/semantic-search"
+    router.pathname === "/resources/semantic-search"
       ? "HSS Landing Page"
-      : path.startsWith("/resources/semantic-search/results")
+      : router.pathname.startsWith("/resources/semantic-search/results")
       ? "HSS Results Page"
       : "Unknown"
 
-  const [searchInputValue, setSearchInputValue] = useState(
-    getQueryParam(redirectQueryParam) ?? ""
-  )
-  const [selectedSuggestions, setSelectedSuggestions] = useState(
-    getRandomSuggestions(3)
-  )
+  const [searchInputValue, setSearchInputValue] = useState("")
+  const [selectedSuggestions, setSelectedSuggestions] = useState([])
+
+  useEffect(() => {
+    const value = getQueryParam(redirectQueryParam)
+    if (value) setSearchInputValue(value)
+  }, [redirectQueryParam])
+
+  useEffect(() => {
+    setSelectedSuggestions(getRandomSuggestions(3))
+  }, [])
 
   // Fire analytics BEFORE navigation
   const searchTermHandler = (term) => {

--- a/components/sections/semantic-search/components/Tabs.js
+++ b/components/sections/semantic-search/components/Tabs.js
@@ -38,51 +38,54 @@ export function SemanticSearchTabs({ currentTabIndex, setCurrentTabIndex }) {
   const [helpModalOpen, setHelpModalOpen] = useState(false)
 
   return (
-    <StyledTabs
-      value={currentTabIndex}
-      onChange={(_, i) => setCurrentTabIndex(i)}
-      aria-label="Results tabs"
-    >
-      <StyledTab
-        label="Studies"
-        {...a11yProps(0)}
-        onClick={() => {
-          sendCustomEvent("hss_panel_selected", {
-            panel_index: "Studies",
-          })
-        }}
-      />
-      <StyledTab
-        label="CDEs"
-        {...a11yProps(1)}
-        onClick={() => {
-          sendCustomEvent("hss_panel_selected", {
-            panel_index: "CDEs",
-          })
-        }}
-      />
-      <StyledTab
-        label="Related Concepts"
-        {...a11yProps(2)}
-        onClick={() => {
-          sendCustomEvent("hss_panel_selected", {
-            panel_index: "Related Concepts",
-          })
-        }}
-      />
-      <StyledTab
-        label="Variables"
-        {...a11yProps(3)}
-        onClick={() => {
-          sendCustomEvent("hss_panel_selected", {
-            panel_index: "Variables",
-          })
-        }}
-      />
+    <div className="flex items-center">
+      <StyledTabs
+        value={currentTabIndex}
+        onChange={(_, i) => setCurrentTabIndex(i)}
+        aria-label="Results tabs"
+        sx={{ flex: 1 }}
+      >
+        <StyledTab
+          label="Studies"
+          {...a11yProps(0)}
+          onClick={() => {
+            sendCustomEvent("hss_panel_selected", {
+              panel_index: "Studies",
+            })
+          }}
+        />
+        <StyledTab
+          label="CDEs"
+          {...a11yProps(1)}
+          onClick={() => {
+            sendCustomEvent("hss_panel_selected", {
+              panel_index: "CDEs",
+            })
+          }}
+        />
+        <StyledTab
+          label="Related Concepts"
+          {...a11yProps(2)}
+          onClick={() => {
+            sendCustomEvent("hss_panel_selected", {
+              panel_index: "Related Concepts",
+            })
+          }}
+        />
+        <StyledTab
+          label="Variables"
+          {...a11yProps(3)}
+          onClick={() => {
+            sendCustomEvent("hss_panel_selected", {
+              panel_index: "Variables",
+            })
+          }}
+        />
+      </StyledTabs>
       <Button
         variant="text"
         startIcon={<Help />}
-        style={{ textTransform: "none", marginLeft: "auto", color: "#4d2862" }}
+        style={{ textTransform: "none", flexShrink: 0, color: "#4d2862" }}
         onClick={() => setHelpModalOpen(true)}
       >
         Need help?
@@ -122,7 +125,7 @@ export function SemanticSearchTabs({ currentTabIndex, setCurrentTabIndex }) {
           <Markdown>{HELP_CONTENT}</Markdown>
         </Box>
       </Modal>
-    </StyledTabs>
+    </div>
   )
 }
 

--- a/components/sections/semantic-search/components/VariableQuestionDisplay.js
+++ b/components/sections/semantic-search/components/VariableQuestionDisplay.js
@@ -1,8 +1,8 @@
-import { Button, CircularProgress, Collapse } from "@mui/material"
+import { CircularProgress } from "@mui/material"
 import { useQuery } from "utils/use-query"
 import { fetchVariables } from "../data/variables"
-import { useState } from "react"
-import { ChevronRight, ExpandMore } from "@mui/icons-material"
+import { Fragment, useState } from "react"
+import { ChevronRight } from "@mui/icons-material"
 import classNames from "classnames"
 
 export function VariableQuestionDisplay({ variableList }) {
@@ -43,8 +43,8 @@ export function VariableQuestionDisplay({ variableList }) {
   return (
     <div>
       {variables.map((v, i) => (
-        <>
-          <div key={v.id}>
+        <Fragment key={v.id}>
+          <div>
             <h4
               className={classNames("text-lg text-primary font-semibold", {
                 "": i > 0,
@@ -75,7 +75,7 @@ export function VariableQuestionDisplay({ variableList }) {
               )}
           </div>
           {i < variables.length - 1 && <hr className="my-4" />}
-        </>
+        </Fragment>
       ))}
     </div>
   )

--- a/components/sections/semantic-search/panels/cdes.js
+++ b/components/sections/semantic-search/panels/cdes.js
@@ -390,7 +390,9 @@ function SidebarItem({ cde, name, description, onClick, active, searchTerm }) {
   const collection = useCollectionContext()
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => {
         trackLeftListClick({
           entity: cde,
@@ -400,6 +402,18 @@ function SidebarItem({ cde, name, description, onClick, active, searchTerm }) {
         })
 
         onClick()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          trackLeftListClick({
+            entity: cde,
+            panelLocation: PANEL_LOCATIONS.CDES,
+            referringSearchTerm: searchTerm,
+            uiSurface: UI_SURFACES.LEFT_LIST,
+          })
+          onClick()
+        }
       }}
       className={
         `w-full p-4 border-b border-gray-200 cursor-pointer text-left` +
@@ -432,6 +446,6 @@ function SidebarItem({ cde, name, description, onClick, active, searchTerm }) {
         </IconButton>
       </div>
       <p className="text-sm text-gray-500">{description}</p>
-    </button>
+    </div>
   )
 }

--- a/components/sections/semantic-search/panels/concepts.js
+++ b/components/sections/semantic-search/panels/concepts.js
@@ -273,44 +273,40 @@ export const ConceptsPanel = ({ searchTerm }) => {
               <h2 className="text-2xl font-semibold leading-relaxed text-[#592963]">
                 {lowercaseFirstLetters(activeConcept.name)}{" "}
               </h2>
-              <Link
-                href={(() => {
-                  const url = new URL(window.location.href)
-                  url.searchParams.set("q", activeConcept.name)
-                  return url
-                })()}
-                passHref
-              >
-                <Tooltip title="Search for this concept" placement="top">
-                  <IconButton
-                    size="large"
-                    component="a"
-                    onMouseDown={(e) => {
-                      e.stopPropagation()
+              <Tooltip title="Search for this concept" placement="top">
+                <IconButton
+                  size="large"
+                  component="a"
+                  href={(() => {
+                    const url = new URL(window.location.href)
+                    url.searchParams.set("q", activeConcept.name)
+                    return url.toString()
+                  })()}
+                  onMouseDown={(e) => {
+                    e.stopPropagation()
 
+                    trackNewConceptSearched({
+                      concept: activeConcept,
+                      panelLocation: PANEL_LOCATIONS.CONCEPTS,
+                      uiSurface: UI_SURFACES.RIGHT_DETAIL,
+                      referringSearchTerm: searchTerm,
+                    })
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault()
                       trackNewConceptSearched({
                         concept: activeConcept,
                         panelLocation: PANEL_LOCATIONS.CONCEPTS,
                         uiSurface: UI_SURFACES.RIGHT_DETAIL,
                         referringSearchTerm: searchTerm,
                       })
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault()
-                        trackNewConceptSearched({
-                          concept: activeConcept,
-                          panelLocation: PANEL_LOCATIONS.CONCEPTS,
-                          uiSurface: UI_SURFACES.RIGHT_DETAIL,
-                          referringSearchTerm: searchTerm,
-                        })
-                      }
-                    }}
-                  >
-                    <Search fontSize="large" sx={{ color: "#4d2862" }} />
-                  </IconButton>
-                </Tooltip>
-              </Link>
+                    }
+                  }}
+                >
+                  <Search fontSize="large" sx={{ color: "#4d2862" }} />
+                </IconButton>
+              </Tooltip>
             </div>
 
             <IconButton
@@ -334,24 +330,20 @@ export const ConceptsPanel = ({ searchTerm }) => {
                 <BookmarkBorder fontSize="large" sx={{ color: "#4d2862" }} />
               )}
             </IconButton>
-            <Link
-              href={(() => {
-                const url = new URL(window.location.href)
-                url.searchParams.set("q", activeConcept.name)
-                return url
-              })()}
-              passHref
-            >
-              <Tooltip title="Search for this concept" placement="top">
-                <IconButton
-                  size="large"
-                  component={"a"}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  <Search fontSize="large" sx={{ color: "#4d2862" }} />
-                </IconButton>
-              </Tooltip>
-            </Link>
+            <Tooltip title="Search for this concept" placement="top">
+              <IconButton
+                size="large"
+                component="a"
+                href={(() => {
+                  const url = new URL(window.location.href)
+                  url.searchParams.set("q", activeConcept.name)
+                  return url.toString()
+                })()}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <Search fontSize="large" sx={{ color: "#4d2862" }} />
+              </IconButton>
+            </Tooltip>
           </div>
           <div className="mb-2 flex gap-2 flex-wrap">
             <p className="text-gray-600 bg-gray-100 border-[1px] border-gray-200 border-solid px-2 py-1 rounded-lg shadow-sm">
@@ -445,7 +437,9 @@ function SidebarItem({
   const collection = useCollectionContext()
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => {
         trackLeftListClick({
           entity: concept,
@@ -456,6 +450,18 @@ function SidebarItem({
 
         onClick()
       }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          trackLeftListClick({
+            entity: concept,
+            panelLocation: PANEL_LOCATIONS.CONCEPTS,
+            referringSearchTerm: searchTerm,
+            uiSurface: UI_SURFACES.LEFT_LIST,
+          })
+          onClick()
+        }
+      }}
       className={
         `w-full p-4 border-b border-gray-200 cursor-pointer text-left` +
         (active ? " bg-[#eeecf0]" : "")
@@ -464,44 +470,40 @@ function SidebarItem({
       <div className="flex gap-2 items-start justify-between">
         <div className="flex gap-1 items-center">
           <h4 className="font-semibold">{name}</h4>
-          <Link
-            href={(() => {
-              const url = new URL(window.location.href)
-              url.searchParams.set("q", name)
-              return url
-            })()}
-            passHref
-          >
-            <Tooltip title="Search for this concept" placement="top">
-              <IconButton
-                size="small"
-                component="a"
-                onMouseDown={(e) => {
-                  e.stopPropagation()
+          <Tooltip title="Search for this concept" placement="top">
+            <IconButton
+              size="small"
+              component="a"
+              href={(() => {
+                const url = new URL(window.location.href)
+                url.searchParams.set("q", name)
+                return url.toString()
+              })()}
+              onMouseDown={(e) => {
+                e.stopPropagation()
 
+                trackNewConceptSearched({
+                  concept: concept,
+                  panelLocation: PANEL_LOCATIONS.CONCEPTS,
+                  uiSurface: UI_SURFACES.LEFT_LIST,
+                  referringSearchTerm: searchTerm,
+                })
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault()
                   trackNewConceptSearched({
                     concept: concept,
                     panelLocation: PANEL_LOCATIONS.CONCEPTS,
                     uiSurface: UI_SURFACES.LEFT_LIST,
                     referringSearchTerm: searchTerm,
                   })
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.preventDefault()
-                    trackNewConceptSearched({
-                      concept: concept,
-                      panelLocation: PANEL_LOCATIONS.CONCEPTS,
-                      uiSurface: UI_SURFACES.LEFT_LIST,
-                      referringSearchTerm: searchTerm,
-                    })
-                  }
-                }}
-              >
-                <Search fontSize="small" sx={{ color: "#4d2862" }} />
-              </IconButton>
-            </Tooltip>
-          </Link>
+                }
+              }}
+            >
+              <Search fontSize="small" sx={{ color: "#4d2862" }} />
+            </IconButton>
+          </Tooltip>
         </div>
         <IconButton
           size="small"
@@ -527,6 +529,6 @@ function SidebarItem({
         </IconButton>
       </div>
       <p className="text-sm text-gray-500">{description}</p>
-    </button>
+    </div>
   )
 }

--- a/components/sections/semantic-search/panels/studies.js
+++ b/components/sections/semantic-search/panels/studies.js
@@ -563,7 +563,9 @@ function SidebarItem({
   }
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => {
         trackLeftListClick({
           entity: study,
@@ -573,6 +575,18 @@ function SidebarItem({
         })
 
         onClick()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          trackLeftListClick({
+            entity: study,
+            panelLocation: PANEL_LOCATIONS.STUDIES,
+            referringSearchTerm: searchTerm,
+            uiSurface: UI_SURFACES.LEFT_LIST,
+          })
+          onClick()
+        }
       }}
       className={
         `w-full p-4 border-b border-gray-200 cursor-pointer text-left` +
@@ -620,6 +634,6 @@ function SidebarItem({
       {statsText.length > 0 && (
         <p className="text-sm mt-1 text-gray-500">{statsText.join(", ")}</p>
       )}
-    </button>
+    </div>
   )
 }

--- a/components/sections/semantic-search/panels/variables.js
+++ b/components/sections/semantic-search/panels/variables.js
@@ -304,7 +304,9 @@ function SidebarItem({
   const collection = useCollectionContext()
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={() => {
         trackLeftListClick({
           entity: variable,
@@ -314,6 +316,18 @@ function SidebarItem({
         })
 
         onClick()
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          trackLeftListClick({
+            entity: variable,
+            panelLocation: PANEL_LOCATIONS.VARIABLES,
+            referringSearchTerm: searchTerm,
+            uiSurface: UI_SURFACES.LEFT_LIST,
+          })
+          onClick()
+        }
       }}
       className={
         `w-full p-4 border-b border-gray-200 cursor-pointer text-left` +
@@ -346,7 +360,7 @@ function SidebarItem({
         </IconButton>
       </div>
       <p className="text-sm text-gray-500">{description}</p>
-    </button>
+    </div>
   )
 }
 
@@ -443,7 +457,9 @@ function MainContent({ activeVariable, searchTerm }) {
                   {activeVariable.metadata?.crf_name}
                 </h3> */}
                 {activeVariable.metadata?.question_text !== "None" && (
-                  <p className="mt-1">{activeVariable.metadata.question_text}</p>
+                  <p className="mt-1">
+                    {activeVariable.metadata.question_text}
+                  </p>
                 )}
 
                 {variableHasPermissibleValues && (

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,9 @@ module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  compiler: {
+    styledComponents: true,
+  },
   transpilePackages: ["@mui/x-data-grid"],
   images: {
     remotePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@emotion/react": "^11.4.1",
+        "@emotion/server": "^11.11.0",
         "@emotion/styled": "^11.3.0",
         "@headlessui/react": "^1.7.17",
         "@meilisearch/instant-meilisearch": "^0.11.1",
@@ -391,6 +392,26 @@
         "@emotion/unitless": "^0.10.0",
         "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/server": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.11.0.tgz",
+      "integrity": "sha512-6q89fj2z8VBTx9w93kJ5n51hsmtYuFPtZgnc1L8VzRx9ti4EU6EyvF6Nn1H1x3vcCQCF7u2dB2lY4AYJwUW4PA==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/utils": "^1.2.1",
+        "html-tokenize": "^2.0.0",
+        "multipipe": "^1.0.2",
+        "through": "^2.3.8"
+      },
+      "peerDependencies": {
+        "@emotion/css": "^11.0.0-rc.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/css": {
+          "optional": true
+        }
       }
     },
     "node_modules/@emotion/sheet": {
@@ -3602,7 +3623,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/cosmiconfig": {
@@ -4084,6 +4104,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -5620,6 +5649,52 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-tokenize": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+      "integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "~0.1.1",
+        "inherits": "~2.0.1",
+        "minimist": "~1.2.5",
+        "readable-stream": "~1.0.27-1",
+        "through2": "~0.4.1"
+      },
+      "bin": {
+        "html-tokenize": "bin/cmd.js"
+      }
+    },
+    "node_modules/html-tokenize/node_modules/buffer-from": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+      "integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg==",
+      "license": "MIT"
+    },
+    "node_modules/html-tokenize/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/html-tokenize/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/html-tokenize/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
@@ -5673,7 +5748,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -6797,7 +6871,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6808,6 +6881,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multipipe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+      "integrity": "sha512-6uiC9OvY71vzSGX8lZvSqscE7ft9nPupJ8fMjrCNRAUy2LREUW42UL+V/NTrogr6rFgRydUrCX4ZitfpSNkSCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer2": "^0.1.2",
+        "object-assign": "^4.1.0"
+      }
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -9394,7 +9477,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prop-types": {
@@ -9691,7 +9773,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -9707,7 +9788,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
@@ -9900,7 +9980,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-push-apply": {
@@ -10220,7 +10299,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -10688,6 +10766,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
+    },
+    "node_modules/through2": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+      "integrity": "sha512-45Llu+EwHKtAZYTPPVn3XZHBgakWMN3rokhEv5hu596XP+cNgplMg+Gj+1nmAvj+L0K7+N49zBKx5rah5u0QIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "~1.0.17",
+        "xtend": "~2.1.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha512-ncrLw+X55z7bkl5PnUvHwFK9FcGuFYo9gtjws2XtSzL+aZ8tm830P60WJ0dSmFVaSalWieW5MD7kEdnXda9yJw==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
+    "node_modules/through2/node_modules/xtend": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+      "integrity": "sha512-vMNKzr2rHP9Dp/e1NQFnLQlwlhp9L/LfvnsVdHxN1f+uggyVI3i08uD14GPvCToPkdsRfyPqIyYGmIk58V98ZQ==",
+      "dependencies": {
+        "object-keys": "~0.4.0"
+      },
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/tiny-warning": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   ],
   "dependencies": {
     "@emotion/react": "^11.4.1",
+    "@emotion/server": "^11.11.0",
     "@emotion/styled": "^11.3.0",
     "@headlessui/react": "^1.7.17",
     "@meilisearch/instant-meilisearch": "^0.11.1",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,18 +6,25 @@ import { DefaultSeo } from "next-seo"
 import { getStrapiMedia } from "utils/media"
 import { getGlobalData } from "utils/api"
 import { SessionProvider } from "next-auth/react"
-// import { useEffect } from "react"
 import { RouteGuard } from "@/components/route-guard"
-import { ThemeProvider } from "@emotion/react"
+import { CacheProvider } from "@emotion/react"
+import { ThemeProvider } from "@mui/material/styles"
+import createEmotionCache from "utils/createEmotionCache"
 import { theme } from "../styles/theme"
 import "@/styles/index.css"
+
+const clientSideEmotionCache = createEmotionCache()
 
 const options = {
   api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
   defaults: "2025-11-30",
 }
 
-const MyApp = ({ Component, pageProps }) => {
+const MyApp = ({
+  Component,
+  pageProps,
+  emotionCache = clientSideEmotionCache,
+}) => {
   // Extract the data we need
   const { global } = pageProps
   if (global == null) {
@@ -27,36 +34,38 @@ const MyApp = ({ Component, pageProps }) => {
   const { metadata } = global
 
   return (
-    <SessionProvider session={pageProps.session}>
-      <Head>
-        <link rel="shortcut icon" href={getStrapiMedia(global.favicon.url)} />
-      </Head>
-      {/* Global site metadata */}
-      <DefaultSeo
-        titleTemplate={`%s | ${global.metaTitleSuffix}`}
-        title="Page"
-        description={metadata.metaDescription}
-        openGraph={{
-          images: Object.values(metadata.shareImage.formats).map((image) => {
-            return {
-              url: getStrapiMedia(image.url),
-              width: image.width,
-              height: image.height,
-            }
-          }),
-        }}
-        twitter={{
-          cardType: metadata.twitterCardType,
-          handle: metadata.twitterUsername,
-        }}
-      />
-      {/* Display the content */}
-      <RouteGuard>
-        <ThemeProvider theme={theme}>
-          <Component {...pageProps} />
-        </ThemeProvider>
-      </RouteGuard>
-    </SessionProvider>
+    <CacheProvider value={emotionCache}>
+      <SessionProvider session={pageProps.session}>
+        <Head>
+          <link rel="shortcut icon" href={getStrapiMedia(global.favicon.url)} />
+        </Head>
+        {/* Global site metadata */}
+        <DefaultSeo
+          titleTemplate={`%s | ${global.metaTitleSuffix}`}
+          title="Page"
+          description={metadata.metaDescription}
+          openGraph={{
+            images: Object.values(metadata.shareImage.formats).map((image) => {
+              return {
+                url: getStrapiMedia(image.url),
+                width: image.width,
+                height: image.height,
+              }
+            }),
+          }}
+          twitter={{
+            cardType: metadata.twitterCardType,
+            handle: metadata.twitterUsername,
+          }}
+        />
+        {/* Display the content */}
+        <RouteGuard>
+          <ThemeProvider theme={theme}>
+            <Component {...pageProps} />
+          </ThemeProvider>
+        </RouteGuard>
+      </SessionProvider>
+    </CacheProvider>
   )
 }
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,11 +1,27 @@
 import React from "react"
 import Document, { Html, Head, Main, NextScript } from "next/document"
+import createEmotionServer from "@emotion/server/create-instance"
+import createEmotionCache from "utils/createEmotionCache"
+import { ServerStyleSheet } from "styled-components"
 
 export default class MyDocument extends Document {
   render() {
     return (
       <Html lang="en">
         <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link
+            rel="preconnect"
+            href="https://fonts.gstatic.com"
+            crossOrigin="anonymous"
+          />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap"
+            rel="stylesheet"
+          />
+          {this.props.styles}
+          <meta name="emotion-insertion-point" content="" />
+          {this.props.emotionStyleTags}
           <script
             async
             src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS}`}
@@ -29,5 +45,45 @@ export default class MyDocument extends Document {
         </body>
       </Html>
     )
+  }
+}
+
+MyDocument.getInitialProps = async (ctx) => {
+  const originalRenderPage = ctx.renderPage
+  const cache = createEmotionCache()
+  const { extractCriticalToChunks } = createEmotionServer(cache)
+  const sheet = new ServerStyleSheet()
+
+  ctx.renderPage = () =>
+    originalRenderPage({
+      enhanceApp: (App) =>
+        function EnhanceApp(props) {
+          return sheet.collectStyles(<App emotionCache={cache} {...props} />)
+        },
+    })
+
+  try {
+    const initialProps = await Document.getInitialProps(ctx)
+    const emotionStyles = extractCriticalToChunks(initialProps.html)
+    const emotionStyleTags = emotionStyles.styles.map((style) => (
+      <style
+        data-emotion={`${style.key} ${style.ids.join(" ")}`}
+        key={style.key}
+        dangerouslySetInnerHTML={{ __html: style.css }}
+      />
+    ))
+
+    return {
+      ...initialProps,
+      emotionStyleTags,
+      styles: (
+        <>
+          {initialProps.styles}
+          {sheet.getStyleElement()}
+        </>
+      ),
+    }
+  } finally {
+    sheet.seal()
   }
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
 @tailwind base;
 @layer base {
   /* Extending Preflight */

--- a/utils/createEmotionCache.js
+++ b/utils/createEmotionCache.js
@@ -1,0 +1,14 @@
+import createCache from "@emotion/cache"
+
+export default function createEmotionCache() {
+  let insertionPoint
+
+  if (typeof document !== "undefined") {
+    const emotionInsertionPoint = document.querySelector(
+      'meta[name="emotion-insertion-point"]'
+    )
+    insertionPoint = emotionInsertionPoint ?? undefined
+  }
+
+  return createCache({ key: "css", insertionPoint })
+}

--- a/utils/use-local-storage.js
+++ b/utils/use-local-storage.js
@@ -1,20 +1,16 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 export const useLocalStorage = (key, initialValue) => {
-  // State to store our value
-  // Pass initial state function to useState so logic is only executed once
-  const [storedValue, setStoredValue] = useState(() => {
+  const [storedValue, setStoredValue] = useState(initialValue)
+
+  useEffect(() => {
     try {
-      // Get from local storage by key
       const item = window.localStorage.getItem(key)
-      // Parse stored json or if none return initialValue
-      return item ? JSON.parse(item) : initialValue
+      if (item) setStoredValue(JSON.parse(item))
     } catch (error) {
-      // If error also return initialValue
       console.error(error.message)
-      return initialValue
     }
-  })
+  }, [key])
 
   // Return a wrapped version of useState's setter function that ...
   // ... persists the new value to localStorage.

--- a/utils/use-query-params.js
+++ b/utils/use-query-params.js
@@ -22,16 +22,18 @@ if (typeof window !== "undefined") {
  * @returns {[string | null, (value: string | null | ((prev: string | null) => string | null)) => void]}
  */
 export const useQueryParam = (initialState, key) => {
-  const [state, setState] = useState(() => {
-    if (typeof window === "undefined") return initialState
-    return new URLSearchParams(window.location.search).get(key) ?? initialState
-  })
+  const [state, setState] = useState(initialState)
 
   const stateRef = useRef(state)
   stateRef.current = state
 
-  // subscribe to the shared notification channel
   useEffect(() => {
+    // Sync from URL on mount, then subscribe to future changes
+    const fromUrl = new URLSearchParams(window.location.search).get(key)
+    if (fromUrl !== null && fromUrl !== stateRef.current) {
+      setState(fromUrl)
+    }
+
     return subscribe(() => {
       const next = new URLSearchParams(window.location.search).get(key)
       if (next !== stateRef.current) {
@@ -102,21 +104,15 @@ function readParams(keys) {
 export const useQueryParams = (config) => {
   const keysRef = useRef(Object.keys(config))
 
-  const [values, dispatch] = useReducer(paramsReducer, config, (initial) => {
-    if (typeof window === "undefined") return initial
-    const fromUrl = readParams(Object.keys(initial))
-    // url values take precedence over initial values.
-    const merged = {}
-    for (const key of Object.keys(initial)) {
-      merged[key] = fromUrl[key] ?? initial[key]
-    }
-    return merged
-  })
+  const [values, dispatch] = useReducer(paramsReducer, config)
 
   const valuesRef = useRef(values)
   valuesRef.current = values
 
   useEffect(() => {
+    // Sync from URL on mount, then subscribe to future changes
+    dispatch({ type: "sync", next: readParams(keysRef.current) })
+
     return subscribe(() => {
       const next = readParams(keysRef.current)
       dispatch({ type: "sync", next })


### PR DESCRIPTION
## Full Summary of Changes

---

## Hydration fixes (SSR/client state mismatches)

- *`utils/use-local-storage.js`*  
  Changed `useState` initializer from reading `localStorage` directly to `useState(initialValue)` + `useEffect` to read after mount.

- *`utils/use-query-params.js`*  
  Same pattern: both `useQueryParam` and `useQueryParams` now initialize with safe defaults and sync from `window.location.search` in a `useEffect`.

- *`components/sections/semantic-search/components/IntegratedSearchBar.js`*  
  `selectedSuggestions` (random) and `searchInputValue` (URL-derived) both start as empty and are populated in `useEffect`.

---

## Invalid HTML nesting

- *`components/sections/semantic-search/panels/concepts.js`*  
- *`components/sections/semantic-search/panels/studies.js`*  
- *`components/sections/semantic-search/panels/cdes.js`*  
- *`components/sections/semantic-search/panels/variables.js`*  

  All four `SidebarItem` components changed from:

  ```html
  <button>
    <IconButton />
  </button>
  ```

  to:

  ```html
  <div role="button" tabIndex={0} onKeyDown={...}>
    <IconButton />
  </div>
  ```

- *`components/elements/link.js`*  
  `InternalLink` was:

  ```html
  <NextLink>
    <MUILink>
      <a />
    </MUILink>
  </NextLink>
  ```

  (nested anchors)

  Changed to:

  ```jsx
  <MUILink component={NextLink} />
  ```

- *`components/sections/semantic-search/panels/concepts.js`*  

  Removed:

  ```jsx
  <Link passHref>
    <IconButton component="a" />
  </Link>
  ```

  Replaced with:

  ```jsx
  <IconButton href="..." />
  ```

---

## MUI / Tabs prop leakage

- *`components/sections/semantic-search/components/Tabs.js`*  

  Moved the **"Need help?"** `Button` and `Modal` outside of `StyledTabs` so MUI's `Tabs` component no longer injects props like:

  ```
  indicator
  selectionFollowsFocus
  textColor
  selected
  ```

  onto the `Button`.

---

## Missing React key

- *`components/sections/semantic-search/components/VariableQuestionDisplay.js`*  

  Changed:

  ```jsx
  <>
    <div key={v.id} />
  </>
  ```

  to:

  ```jsx
  <Fragment key={v.id}>
    <div />
  </Fragment>
  ```

---

## CSS-in-JS SSR setup

- *`utils/createEmotionCache.js`* (new file)  

  Creates an Emotion cache using:

  ```html
  <meta name="emotion-insertion-point" />
  ```

  as the DOM insertion point so the client cache can adopt server-rendered class names.

- *`pages/_document.js`*  

  Added:

  - Full Emotion SSR extraction (`@emotion/server` + `extractCriticalToChunks`)
  - `styled-components` `ServerStyleSheet` collection
  - `{this.props.styles}` and `{this.props.emotionStyleTags}` in `<Head>`
  - `<meta name="emotion-insertion-point">`
  - Google Fonts `<link>` preconnect and stylesheet tags

- *`pages/_app.js`*  

  - Added `CacheProvider` from `@emotion/react` wrapping the entire app with the server-passed or client-side Emotion cache  
  - Changed `ThemeProvider` import from `@emotion/react` → `@mui/material/styles` so MUI's internal theme context is set correctly on both server and client

- *`next.config.js`*  

  ```js
  compiler: { styledComponents: true }
  ```

---

## Fonts

- *`pages/_document.js`*  

  Added:

  ```html
  <link rel="preconnect" href="https://fonts.googleapis.com" />
  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat&display=swap" />
  ```

- *`styles/index.css`*  

  Removed:

  ```css
  @import url("https://fonts.googleapis.com/css2?family=Montserrat&display=swap");
  ```
