### PR TITLE
Wrap related concept searches with double-quotes

### DIFF
--- a/components/sections/semantic-search/components/RelatedSearches.js
+++ b/components/sections/semantic-search/components/RelatedSearches.js
@@ -49,7 +49,7 @@ export function RelatedSearches({ searchTerm }) {
       </div>
       <hr className="my-4" />
       <div className="flex flex-col">
-        {concepts.map((term) => {`2323`
+        {concepts.map((term) => {
           const queryTerm =
             term.name.includes(" ") &&
             !(term.name.startsWith('"') && term.name.endsWith('"'))

--- a/components/sections/semantic-search/components/RelatedSearches.js
+++ b/components/sections/semantic-search/components/RelatedSearches.js
@@ -49,30 +49,37 @@ export function RelatedSearches({ searchTerm }) {
       </div>
       <hr className="my-4" />
       <div className="flex flex-col">
-        {concepts.map((term) => (
-          <Link
-            to={`/resources/semantic-search/results?${new URLSearchParams({
-              q: term.name,
-            })}`}
-            key={term.id}
-            onMouseDown={() => {
-              sendCustomEvent("hss_related_search_clicked", {
-                referring_search_term: searchTerm,
-                related_search_term: term.name,
-              })
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
+        {concepts.map((term) => {`2323`
+          const queryTerm =
+            term.name.includes(" ") &&
+            !(term.name.startsWith('"') && term.name.endsWith('"'))
+              ? `"${term.name}"`
+              : term.name
+          return (
+            <Link
+              to={`/resources/semantic-search/results?${new URLSearchParams({
+                q: queryTerm,
+              })}`}
+              key={term.id}
+              onMouseDown={() => {
                 sendCustomEvent("hss_related_search_clicked", {
                   referring_search_term: searchTerm,
                   related_search_term: term.name,
                 })
-              }
-            }}
-          >
-            {term.name}
-          </Link>
-        ))}
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  sendCustomEvent("hss_related_search_clicked", {
+                    referring_search_term: searchTerm,
+                    related_search_term: term.name,
+                  })
+                }
+              }}
+            >
+              {term.name}
+            </Link>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
As per https://renci.atlassian.net/browse/DUG-697, related concepts searches should be surrounded by double quotes to provide the most specific results. The double-quotes are only added if (1) the concept includes a space, and (2) it is not already surrounded by double-quotes (note that if it starts or ends with double-quotes, those will be quoted as well). The term is not quoted in custom events to simplify tracking.